### PR TITLE
Update compile.tcl to avoid `reset_run` error

### DIFF
--- a/hw/scripts/compile.tcl.in
+++ b/hw/scripts/compile.tcl.in
@@ -96,15 +96,16 @@ eval $cmd
 
 # Reset previous
 if {$cfg(en_pr) eq 1} {
-	set cmd "reset_run "
 	for {set j 1}  {$j <= $i} {incr j} {
+		set cmd "reset_run "
 		append cmd "impl_$j "
+		eval $cmd
 	}
 } else {
 	set cmd "reset_run "
 	append cmd "impl_1 "
+	eval $cmd
 }
-eval $cmd
 
 # Launch
 if {$cfg(en_pr) eq 1} {


### PR DESCRIPTION
the script generates commands like `reset_run impl_1 impl_2` but the TCl command `reset_run` does not allow multiple targets in Vivado 2021.1, causing an error during `make dynamic` and `make compile`. 

Fix: do multiple `reset_run impl_$i` instead of `reset_run impl_1 impl_2 ...`