### PR TITLE
refactorize the bypass done to include dest and stream field

### DIFF
--- a/hw/hdl/common/ccross/meta_ccross.sv
+++ b/hw/hdl/common/ccross/meta_ccross.sv
@@ -28,6 +28,20 @@ if(DATA_BITS == 6) begin
 		.m_axis_tdata(m_meta.data)
 	);
 end
+if(DATA_BITS == 11) begin
+	meta_clock_converter_16 inst_reg_slice (
+		.s_axis_aclk(s_aclk),
+		.s_axis_aresetn(s_aresetn),
+		.m_axis_aclk(m_aclk),
+		.m_axis_aresetn(m_aresetn),
+		.s_axis_tvalid(s_meta.valid),
+		.s_axis_tready(s_meta.ready),
+		.s_axis_tdata(s_meta.data),
+		.m_axis_tvalid(m_meta.valid),
+		.m_axis_tready(m_meta.ready),
+		.m_axis_tdata(m_meta.data)
+	);
+end
 if(DATA_BITS == 96) begin
 	meta_clock_converter_96 inst_reg_slice (
 		.s_axis_aclk(s_aclk),

--- a/hw/hdl/common/regs/meta_reg.sv
+++ b/hw/hdl/common/regs/meta_reg.sv
@@ -24,6 +24,18 @@ if(DATA_BITS == 6) begin
 		.m_axis_tdata(m_meta.data)
 	);
 end
+if(DATA_BITS == 11) begin
+	axis_register_slice_meta_16 inst_reg_slice (
+		.aclk(aclk),
+		.aresetn(aresetn),
+		.s_axis_tvalid(s_meta.valid),
+		.s_axis_tready(s_meta.ready),
+		.s_axis_tdata(s_meta.data),
+		.m_axis_tvalid(m_meta.valid),
+		.m_axis_tready(m_meta.ready),
+		.m_axis_tdata(m_meta.data)
+	);
+end
 if(DATA_BITS == 32) begin
 	axis_register_slice_meta_32 inst_reg_slice (
 		.aclk(aclk),

--- a/hw/hdl/mmu/tlb_fsm_rd.sv
+++ b/hw/hdl/mmu/tlb_fsm_rd.sv
@@ -334,14 +334,14 @@ always_comb begin: DP
 	// Config
 `ifdef EN_STRM
 	m_host_done.valid = m_HDMA.rsp.done;
-	m_host_done.data = m_HDMA.rsp.pid;
+	m_host_done.data = {m_HDMA.rsp.stream, m_HDMA.rsp.dest, m_HDMA.rsp.pid};
 `endif
 
 `ifdef EN_MEM
 	m_card_done.valid = m_DDMA.rsp.done;
-	m_card_done.data = m_DDMA.rsp.pid;
+	m_card_done.data = {m_DDMA.rsp.stream, m_DDMA.rsp.dest, m_DDMA.rsp.pid};
 	m_sync_done.valid = m_IDMA.rsp.done & ~m_IDMA.rsp.isr;
-	m_sync_done.data = m_IDMA.rsp.pid;
+	m_sync_done.data = {m_IDMA.rsp.stream, m_IDMA.rsp.dest, m_IDMA.rsp.pid};
 `endif
 
 	m_pfault.valid = miss_C;
@@ -367,6 +367,7 @@ always_comb begin: DP
 	m_HDMA.req.ctl = 1'b0;
 	m_HDMA.req.dest = dest_C;
 	m_HDMA.req.pid = pid_C;
+	m_HDMA.req.stream = strm_C;
 	m_HDMA.req.rsrvd = 0;
 	m_HDMA.valid = 1'b0;
 `endif
@@ -378,6 +379,7 @@ always_comb begin: DP
 	m_DDMA.req.ctl = 1'b0;
 	m_DDMA.req.dest = dest_C;
 	m_DDMA.req.pid = pid_C;
+	m_DDMA.req.stream = strm_C;
 	m_DDMA.req.rsrvd = 0;
 	m_DDMA.valid = 1'b0;
 
@@ -389,6 +391,7 @@ always_comb begin: DP
 	m_IDMA.req.dest = dest_C;
 	m_IDMA.req.pid = pid_C;
     m_IDMA.req.isr = 1'b0;
+	m_IDMA.req.stream = strm_C;
 	m_IDMA.req.rsrvd = 0;
 	m_IDMA.valid = 1'b0;
 `endif

--- a/hw/hdl/mmu/tlb_fsm_wr.sv
+++ b/hw/hdl/mmu/tlb_fsm_wr.sv
@@ -335,14 +335,14 @@ always_comb begin: DP
 	// Config
 `ifdef EN_STRM
     m_host_done.valid = m_HDMA.rsp.done;
-	m_host_done.data = m_HDMA.rsp.pid;
+	m_host_done.data = {m_HDMA.rsp.stream, m_HDMA.rsp.dest, m_HDMA.rsp.pid};
 `endif
 
 `ifdef EN_MEM
 	m_card_done.valid = m_DDMA.rsp.done;
-	m_card_done.data = m_DDMA.rsp.pid;
+	m_card_done.data = {m_DDMA.rsp.stream, m_DDMA.rsp.dest, m_DDMA.rsp.pid};
 	m_sync_done.valid = m_SDMA.rsp.done;
-	m_sync_done.data = m_SDMA.rsp.pid;
+	m_sync_done.data = {m_SDMA.rsp.stream, m_SDMA.rsp.dest, m_SDMA.rsp.pid};
 `endif
 	
     m_pfault.valid = miss_C;
@@ -368,6 +368,7 @@ always_comb begin: DP
 	m_HDMA.req.ctl = 1'b0;
 	m_HDMA.req.dest = dest_C;
 	m_HDMA.req.pid = pid_C;
+	m_HDMA.req.stream = strm_C;
 	m_HDMA.req.rsrvd = 0;
 	m_HDMA.valid = 1'b0;
 `endif
@@ -379,6 +380,7 @@ always_comb begin: DP
 	m_DDMA.req.ctl = 1'b0;
 	m_DDMA.req.dest = dest_C;
 	m_DDMA.req.pid = pid_C;
+	m_DDMA.req.stream = strm_C;
 	m_DDMA.req.rsrvd = 0;
 	m_DDMA.valid = 1'b0;
 
@@ -390,6 +392,7 @@ always_comb begin: DP
 	m_IDMA.req.dest = dest_C;
 	m_IDMA.req.pid = pid_C;
     m_IDMA.req.isr = 1'b0;
+	m_IDMA.req.stream = strm_C;
 	m_IDMA.req.rsrvd = 0;
 	m_IDMA.valid = 1'b0;
 
@@ -401,6 +404,7 @@ always_comb begin: DP
 	m_SDMA.req.dest = dest_C;
 	m_SDMA.req.pid = pid_C;
     m_SDMA.req.isr = 1'b0;
+	m_SDMA.req.stream = strm_C;
 	m_SDMA.req.rsrvd = 0;
 	m_SDMA.valid = 1'b0;
 `endif

--- a/hw/hdl/mmu/tlb_region_top.sv
+++ b/hw/hdl/mmu/tlb_region_top.sv
@@ -147,14 +147,14 @@ tlbIntf #(.TLB_INTF_DATA_BITS(TLB_L_DATA_BITS)) lTlb ();
 tlbIntf #(.TLB_INTF_DATA_BITS(TLB_S_DATA_BITS)) sTlb ();
 
 `ifdef EN_STRM
-metaIntf #(.STYPE(logic[PID_BITS-1:0])) rd_host_done ();
-metaIntf #(.STYPE(logic[PID_BITS-1:0])) wr_host_done ();
+metaIntf #(.STYPE(logic[PID_BITS+DEST_BITS+1-1:0])) rd_host_done ();
+metaIntf #(.STYPE(logic[PID_BITS+DEST_BITS+1-1:0])) wr_host_done ();
 `endif
 `ifdef EN_MEM
-metaIntf #(.STYPE(logic[PID_BITS-1:0])) rd_card_done ();
-metaIntf #(.STYPE(logic[PID_BITS-1:0])) rd_sync_done ();
-metaIntf #(.STYPE(logic[PID_BITS-1:0])) wr_card_done ();
-metaIntf #(.STYPE(logic[PID_BITS-1:0])) wr_sync_done ();
+metaIntf #(.STYPE(logic[PID_BITS+DEST_BITS+1-1:0])) rd_card_done ();
+metaIntf #(.STYPE(logic[PID_BITS+DEST_BITS+1-1:0])) rd_sync_done ();
+metaIntf #(.STYPE(logic[PID_BITS+DEST_BITS+1-1:0])) wr_card_done ();
+metaIntf #(.STYPE(logic[PID_BITS+DEST_BITS+1-1:0])) wr_sync_done ();
 `endif
 
 metaIntf #(.STYPE(pfault_t)) rd_pfault ();

--- a/hw/hdl/mmu/xdma_assign.sv
+++ b/hw/hdl/mmu/xdma_assign.sv
@@ -48,6 +48,8 @@ assign m_xdma.h2c_valid           = s_dma_rd.valid & m_xdma.h2c_ready;
 assign s_dma_rd.ready             = m_xdma.h2c_ready;
 assign s_dma_rd.rsp.done          = m_xdma.h2c_status[1];
 assign s_dma_rd.rsp.pid           = 0;
+assign s_dma_rd.rsp.dest          = 0;
+assign s_dma_rd.rsp.stream        = 0;
 
 // WR
 assign m_xdma.c2h_ctl             = {{11{1'b0}}, s_dma_wr.req.ctl, {2{1'b0}}, {2{s_dma_wr.req.ctl}}};
@@ -57,5 +59,7 @@ assign m_xdma.c2h_valid           = s_dma_wr.valid & m_xdma.c2h_ready;
 assign s_dma_wr.ready             = m_xdma.c2h_ready;
 assign s_dma_wr.rsp.done          = m_xdma.c2h_status[1];
 assign s_dma_wr.rsp.pid           = 0;
+assign s_dma_wr.rsp.dest          = 0;
+assign s_dma_wr.rsp.stream        = 0;
 
 endmodule

--- a/hw/hdl/operators/examples/perf_fpga/perf_fpga_c0_0.svh
+++ b/hw/hdl/operators/examples/perf_fpga/perf_fpga_c0_0.svh
@@ -23,6 +23,7 @@ logic [LEN_BITS-1:0] bench_len;
 logic [PID_BITS-1:0] bench_pid;
 logic [31:0] bench_n_reps;
 logic [63:0] bench_n_beats;
+logic [DEST_BITS-1:0] bench_dest;
 
 logic done_req;
 logic done_data;
@@ -60,7 +61,8 @@ perf_fpga_slv inst_slave (
     .bench_len(bench_len),
     .bench_pid(bench_pid),
     .bench_n_reps(bench_n_reps),
-    .bench_n_beats(bench_n_beats)
+    .bench_n_beats(bench_n_beats),
+    .bench_dest(bench_dest)
 );
 
 // REG
@@ -133,6 +135,7 @@ always_comb begin
     bpss_rd_req.data.len = bench_len;
     bpss_rd_req.data.pid = bench_pid;
     bpss_rd_req.data.ctl = 1'b1;
+    bpss_rd_req.data.dest = bench_dest;
     bpss_rd_req.valid = (state_C == ST_READ) && ~done_req;
 
     bpss_wr_req.data = 0;
@@ -140,6 +143,7 @@ always_comb begin
     bpss_wr_req.data.len = bench_len;
     bpss_wr_req.data.pid = bench_pid;
     bpss_wr_req.data.ctl = 1'b1;
+    bpss_wr_req.data.dest = bench_dest;
     bpss_wr_req.valid = (state_C == ST_WRITE) && ~done_req;
 
     bpss_rd_done.ready = 1'b1;
@@ -155,7 +159,25 @@ always_comb begin
     axis_src_int.tvalid = (state_C == ST_WRITE) && ~done_data;
 end
 
+
 /*
+// Debug
+logic [PID_BITS-1:0] bpss_rd_done_pid;
+logic bpss_rd_done_stream;
+logic [DEST_BITS-1:0] bpss_rd_done_dest;
+
+logic [PID_BITS-1:0] bpss_wr_done_pid;
+logic bpss_wr_done_stream;
+logic [DEST_BITS-1:0] bpss_wr_done_dest;
+
+assign bpss_rd_done_pid = bpss_rd_done.data[PID_BITS-1:0];
+assign bpss_rd_done_dest = bpss_rd_done.data[PID_BITS+DEST_BITS-1:PID_BITS];
+assign bpss_rd_done_stream = bpss_rd_done.data[PID_BITS+DEST_BITS:PID_BITS+DEST_BITS];
+
+assign bpss_wr_done_pid = bpss_wr_done.data[PID_BITS-1:0];
+assign bpss_wr_done_dest = bpss_wr_done.data[PID_BITS+DEST_BITS-1:PID_BITS];
+assign bpss_wr_done_stream = bpss_wr_done.data[PID_BITS+DEST_BITS:PID_BITS+DEST_BITS];
+
 ila_0 inst_ila_0 (
     .clk(aclk),
     .probe0(bench_ctrl), // 2
@@ -177,6 +199,15 @@ ila_0 inst_ila_0 (
     .probe16(axis_sink_int.tlast),
     .probe17(axis_src_int.tvalid),
     .probe18(axis_src_int.tready),
-    .probe19(axis_src_int.tlast)
+    .probe19(axis_src_int.tlast),
+    .probe20(bpss_rd_done.valid),
+    .probe21(bpss_rd_done_pid), //6
+    .probe22(bpss_rd_done_stream), 
+    .probe23(bpss_rd_done_dest), //4
+    .probe24(bpss_wr_done.valid),
+    .probe25(bpss_wr_done_pid), //6
+    .probe26(bpss_wr_done_stream), 
+    .probe27(bpss_wr_done_dest), //4
+    .probe28(bench_dest) // 4
 );
 */

--- a/hw/scripts/ip_inst/base_infrastructure.tcl
+++ b/hw/scripts/ip_inst/base_infrastructure.tcl
@@ -106,6 +106,9 @@ set_property -dict [list CONFIG.TDATA_NUM_BYTES {32} CONFIG.FIFO_DEPTH {32} ] [g
 create_ip -name axis_register_slice -vendor xilinx.com -library ip -version 1.1 -module_name axis_register_slice_meta_8
 set_property -dict [list CONFIG.TDATA_NUM_BYTES {1} CONFIG.REG_CONFIG {8} ] [get_ips axis_register_slice_meta_8]
 
+create_ip -name axis_register_slice -vendor xilinx.com -library ip -version 1.1 -module_name axis_register_slice_meta_16
+set_property -dict [list CONFIG.TDATA_NUM_BYTES {2} CONFIG.REG_CONFIG {8} ] [get_ips axis_register_slice_meta_16]
+
 create_ip -name axis_register_slice -vendor xilinx.com -library ip -version 1.1 -module_name axis_register_slice_meta_32
 set_property -dict [list CONFIG.TDATA_NUM_BYTES {4} CONFIG.REG_CONFIG {8} ] [get_ips axis_register_slice_meta_32]
 
@@ -129,6 +132,9 @@ set_property -dict [list CONFIG.TDATA_NUM_BYTES {68} CONFIG.REG_CONFIG {8} ] [ge
 
 create_ip -name axis_clock_converter -vendor xilinx.com -library ip -version 1.1 -module_name meta_clock_converter_8
 set_property -dict [list CONFIG.TDATA_NUM_BYTES {1} ] [get_ips meta_clock_converter_8]
+
+create_ip -name axis_clock_converter -vendor xilinx.com -library ip -version 1.1 -module_name meta_clock_converter_16
+set_property -dict [list CONFIG.TDATA_NUM_BYTES {2} ] [get_ips meta_clock_converter_16]
 
 create_ip -name axis_clock_converter -vendor xilinx.com -library ip -version 1.1 -module_name meta_clock_converter_96
 set_property -dict [list CONFIG.TDATA_NUM_BYTES {12} ] [get_ips meta_clock_converter_96]

--- a/hw/scripts/wr_hdl/template_gen/dynamic_wrapper.txt
+++ b/hw/scripts/wr_hdl/template_gen/dynamic_wrapper.txt
@@ -1256,10 +1256,10 @@ module design_dynamic_wrapper #(
     metaIntf #(.STYPE(req_t)) bpss_wr_req [N_REGIONS] ();
     metaIntf #(.STYPE(req_t)) bpss_rd_req_s0 [N_REGIONS] ();
     metaIntf #(.STYPE(req_t)) bpss_wr_req_s0 [N_REGIONS] ();
-    metaIntf #(.STYPE(logic[PID_BITS-1:0])) bpss_rd_done [N_REGIONS] ();
-    metaIntf #(.STYPE(logic[PID_BITS-1:0])) bpss_wr_done [N_REGIONS] ();
-    metaIntf #(.STYPE(logic[PID_BITS-1:0])) bpss_rd_done_s0 [N_REGIONS] ();
-    metaIntf #(.STYPE(logic[PID_BITS-1:0])) bpss_wr_done_s0 [N_REGIONS] ();
+    metaIntf #(.STYPE(logic[PID_BITS+DEST_BITS+1-1:0])) bpss_rd_done [N_REGIONS] ();
+    metaIntf #(.STYPE(logic[PID_BITS+DEST_BITS+1-1:0])) bpss_wr_done [N_REGIONS] ();
+    metaIntf #(.STYPE(logic[PID_BITS+DEST_BITS+1-1:0])) bpss_rd_done_s0 [N_REGIONS] ();
+    metaIntf #(.STYPE(logic[PID_BITS+DEST_BITS+1-1:0])) bpss_wr_done_s0 [N_REGIONS] ();
 {% endif %}	
 
 {% if cnfg.en_uclk %}
@@ -1268,8 +1268,8 @@ module design_dynamic_wrapper #(
 {% if cnfg.en_bpss %}
         meta_ccross #(.DATA_BITS($bits(req_t))) (.s_aclk(uclk), .s_aresetn(uresetn), .m_aclk(aclk), .m_aresetn(aresetn), .s_meta(bpss_rd_req_s0[i]), .m_meta(bpss_rd_req[i]));
         meta_ccross #(.DATA_BITS($bits(req_t))) (.s_aclk(uclk), .s_aresetn(uresetn), .m_aclk(aclk), .m_aresetn(aresetn), .s_meta(bpss_wr_req_s0[i]), .m_meta(bpss_wr_req[i]));
-        meta_ccross #(.DATA_BITS(PID_BITS)) (.s_aclk(aclk), .s_aresetn(aresetn), .m_aclk(uclk), .m_aresetn(uresetn), .s_meta(bpss_rd_done[i]), .m_meta(bpss_rd_done_s0[i]));
-        meta_ccross #(.DATA_BITS(PID_BITS)) (.s_aclk(aclk), .s_aresetn(aresetn), .m_aclk(uclk), .m_aresetn(uresetn), .s_meta(bpss_wr_done[i]), .m_meta(bpss_wr_done_s0[i]));
+        meta_ccross #(.DATA_BITS(PID_BITS+DEST_BITS+1)) (.s_aclk(aclk), .s_aresetn(aresetn), .m_aclk(uclk), .m_aresetn(uresetn), .s_meta(bpss_rd_done[i]), .m_meta(bpss_rd_done_s0[i]));
+        meta_ccross #(.DATA_BITS(PID_BITS+DEST_BITS+1)) (.s_aclk(aclk), .s_aresetn(aresetn), .m_aclk(uclk), .m_aresetn(uresetn), .s_meta(bpss_wr_done[i]), .m_meta(bpss_wr_done_s0[i]));
 {% endif %}	
     end
 
@@ -1292,8 +1292,8 @@ module design_dynamic_wrapper #(
 {% if cnfg.en_bpss %}
     metaIntf #(.STYPE(req_t)) bpss_rd_req_s1 [N_REGIONS] ();
     metaIntf #(.STYPE(req_t)) bpss_wr_req_s1 [N_REGIONS] ();
-    metaIntf #(.STYPE(logic[PID_BITS-1:0])) bpss_rd_done_s1 [N_REGIONS] ();
-    metaIntf #(.STYPE(logic[PID_BITS-1:0])) bpss_wr_done_s1 [N_REGIONS] ();
+    metaIntf #(.STYPE(logic[PID_BITS+DEST_BITS+1-1:0])) bpss_rd_done_s1 [N_REGIONS] ();
+    metaIntf #(.STYPE(logic[PID_BITS+DEST_BITS+1-1:0])) bpss_wr_done_s1 [N_REGIONS] ();
 {% endif %}	
 
     for(genvar i = 0; i < N_REGIONS; i++) begin
@@ -1301,8 +1301,8 @@ module design_dynamic_wrapper #(
 {% if cnfg.en_bpss %}
         meta_reg_array #(.DATA_BITS($bits(req_t)), .N_STAGES(N_REG_DYN_HOST_S1)) (.aclk(aclk), .aresetn(aresetn), .s_meta(bpss_rd_req_s1[i]), .m_meta(bpss_rd_req_s0[i]));
         meta_reg_array #(.DATA_BITS($bits(req_t)), .N_STAGES(N_REG_DYN_HOST_S1)) (.aclk(aclk), .aresetn(aresetn), .s_meta(bpss_wr_req_s1[i]), .m_meta(bpss_wr_req_s0[i]));
-        meta_reg_array #(.DATA_BITS(PID_BITS), .N_STAGES(N_REG_DYN_HOST_S1)) (.aclk(aclk), .aresetn(aresetn), .s_meta(bpss_rd_done_s0[i]), .m_meta(bpss_rd_done_s1[i]));
-        meta_reg_array #(.DATA_BITS(PID_BITS), .N_STAGES(N_REG_DYN_HOST_S1)) (.aclk(aclk), .aresetn(aresetn), .s_meta(bpss_wr_done_s0[i]), .m_meta(bpss_wr_done_s1[i]));
+        meta_reg_array #(.DATA_BITS(PID_BITS+DEST_BITS+1), .N_STAGES(N_REG_DYN_HOST_S1)) (.aclk(aclk), .aresetn(aresetn), .s_meta(bpss_rd_done_s0[i]), .m_meta(bpss_rd_done_s1[i]));
+        meta_reg_array #(.DATA_BITS(PID_BITS+DEST_BITS+1), .N_STAGES(N_REG_DYN_HOST_S1)) (.aclk(aclk), .aresetn(aresetn), .s_meta(bpss_wr_done_s0[i]), .m_meta(bpss_wr_done_s1[i]));
 {% endif %}	
     end	
 
@@ -1312,8 +1312,8 @@ module design_dynamic_wrapper #(
 {% if cnfg.en_bpss %}
     metaIntf #(.STYPE(req_t)) bpss_rd_req_ul [N_REGIONS] ();
     metaIntf #(.STYPE(req_t)) bpss_wr_req_ul [N_REGIONS] ();
-    metaIntf #(.STYPE(logic[PID_BITS-1:0])) bpss_rd_done_ul [N_REGIONS] ();
-    metaIntf #(.STYPE(logic[PID_BITS-1:0])) bpss_wr_done_ul [N_REGIONS] ();
+    metaIntf #(.STYPE(logic[PID_BITS+DEST_BITS+1-1:0])) bpss_rd_done_ul [N_REGIONS] ();
+    metaIntf #(.STYPE(logic[PID_BITS+DEST_BITS+1-1:0])) bpss_wr_done_ul [N_REGIONS] ();
 {% endif %}	
 	axil_decoupler (.decouple(decouple_uclk), .s_axi(axi_ctrl_user_s1), .m_axi(axi_ctrl_user_ul));
 {% if cnfg.en_bpss %}

--- a/hw/scripts/wr_hdl/template_gen/lynx_pkg.txt
+++ b/hw/scripts/wr_hdl/template_gen/lynx_pkg.txt
@@ -332,11 +332,14 @@ package lynxTypes;
         logic ctl;
         logic [DEST_BITS-1:0] dest;
         logic [PID_BITS-1:0] pid;
-        logic [96-PADDR_BITS-LEN_BITS-1-DEST_BITS-PID_BITS-1:0] rsrvd;
+        logic stream;
+        logic [96-PADDR_BITS-LEN_BITS-1-DEST_BITS-PID_BITS-1-1:0] rsrvd;
     } dma_req_t;
 
     typedef struct packed {
         logic [PID_BITS-1:0] pid;
+        logic [DEST_BITS-1:0] dest;
+        logic stream;
         logic done;
     } dma_rsp_t;
 
@@ -348,12 +351,15 @@ package lynxTypes;
         logic [DEST_BITS-1:0] dest;
         logic [PID_BITS-1:0] pid;
         logic isr;
-        logic [128-2*PADDR_BITS-LEN_BITS-1-DEST_BITS-PID_BITS-1-1:0] rsrvd;
+        logic stream;
+        logic [128-2*PADDR_BITS-LEN_BITS-1-DEST_BITS-PID_BITS-1-1-1:0] rsrvd;
     } dma_isr_req_t;
 
     typedef struct packed {
         logic [PID_BITS-1:0] pid;
         logic isr;
+        logic [DEST_BITS-1:0] dest;
+        logic stream;
         logic done;
     } dma_isr_rsp_t;
 

--- a/hw/scripts/wr_hdl/template_gen/user_wrapper.txt
+++ b/hw/scripts/wr_hdl/template_gen/user_wrapper.txt
@@ -41,10 +41,10 @@ module design_user_wrapper_{{ c_reg }} (
     output req_t 							    bpss_wr_req_data,
     input  logic                                bpss_rd_done_valid,
     output logic                                bpss_rd_done_ready,
-    input  logic [PID_BITS-1:0]                 bpss_rd_done_data,
+    input  logic [PID_BITS+DEST_BITS+1-1:0]     bpss_rd_done_data,
     input  logic                                bpss_wr_done_valid,
     output logic                                bpss_wr_done_ready,
-    input  logic [PID_BITS-1:0]                 bpss_wr_done_data,
+    input  logic [PID_BITS+DEST_BITS+1-1:0]     bpss_wr_done_data,
 		
 {% endif %}
 {% if cnfg.en_strm %}
@@ -309,8 +309,8 @@ module design_user_wrapper_{{ c_reg }} (
     assign bpss_wr_req.ready                    = bpss_wr_req_ready;
     assign bpss_wr_req_data                     = bpss_wr_req.data;
 
-    metaIntf #(.STYPE(logic[PID_BITS-1:0])) bpss_rd_done();
-    metaIntf #(.STYPE(logic[PID_BITS-1:0])) bpss_wr_done();
+    metaIntf #(.STYPE(logic[PID_BITS+DEST_BITS+1-1:0])) bpss_rd_done();
+    metaIntf #(.STYPE(logic[PID_BITS+DEST_BITS+1-1:0])) bpss_wr_done();
 
     assign bpss_rd_done.valid                   = bpss_rd_done_valid;
     assign bpss_rd_done_ready                   = 1'b1;

--- a/sw/examples/perf_fpga/main.cpp
+++ b/sw/examples/perf_fpga/main.cpp
@@ -41,7 +41,8 @@ enum class BenchRegs : uint32_t {
     LEN_REG = 4,
     PID_REG = 5,
     N_REPS_REG = 6,
-    N_BEATS_REG = 7
+    N_BEATS_REG = 7,
+    DEST_REG = 8
 };
 
 enum class BenchOper : uint8_t {
@@ -69,6 +70,7 @@ int main(int argc, char *argv[])
     uint32_t n_reps = nReps;
     uint32_t n_pages = (maxSize + hugePageSize - 1) / hugePageSize;
     uint32_t curr_size = defSize;
+    uint32_t dest = 0;
 
     PR_HEADER("PARAMS");
     std::cout << "vFPGA ID: " << targetRegion << std::endl;
@@ -96,6 +98,7 @@ int main(int argc, char *argv[])
 
         uint64_t n_beats = n_reps * ((curr_size + 64 - 1) / 64);
         cproc.setCSR(n_beats, static_cast<uint32_t>(BenchRegs::N_BEATS_REG));
+        cproc.setCSR(dest, static_cast<uint32_t>(BenchRegs::DEST_REG));
 
         // Fire
         cproc.setCSR(static_cast<uint64_t>(oper), static_cast<uint32_t>(BenchRegs::CTRL_REG));


### PR DESCRIPTION
- Refactorize the code to include the dest field and the stream field in the bypass done signal.
- Bypass done signal is extended to 11 bits   MSB {stream, dest, pid} LSB
- Tested the bypass done with new field using perf fpga example, example is updated