### PR TITLE
Fixed a possible bug regarding RDMA write requests originating in user logic

### DIFF
--- a/hw/hdl/user/credits/dreq_credits_wr.sv
+++ b/hw/hdl/user/credits/dreq_credits_wr.sv
@@ -71,6 +71,12 @@ end
 always_comb begin
     cnt_N =  cnt_C;
 
+    // IO
+    s_req.ready = 1'b0;
+    
+    m_req_int.valid = 1'b0;
+    m_req_int.data = s_req.data;
+
     n_beats = (s_req.data.req_1.len) >> BEAT_LOG_BITS;
 
     if(s_req.valid && m_req_int.ready && (cnt_C >= n_beats)) begin
@@ -81,12 +87,6 @@ always_comb begin
     end
     else begin
         cnt_N = xfer ? cnt_C + 1 : cnt_C;
-
-        // IO
-        s_req.ready = 1'b0;
-
-        m_req_int.valid = 1'b0;
-        m_req_int.data = s_req.data;
     end
 
 end

--- a/hw/hdl/user/credits/dreq_credits_wr.sv
+++ b/hw/hdl/user/credits/dreq_credits_wr.sv
@@ -71,12 +71,6 @@ end
 always_comb begin
     cnt_N =  cnt_C;
 
-    // IO
-    s_req.ready = 1'b0;
-    
-    m_req_int.valid = 1'b0;
-    m_req_int.data = s_req.data;
-
     n_beats = (s_req.data.req_1.len) >> BEAT_LOG_BITS;
 
     if(s_req.valid && m_req_int.ready && (cnt_C >= n_beats)) begin
@@ -87,6 +81,12 @@ always_comb begin
     end
     else begin
         cnt_N = xfer ? cnt_C + 1 : cnt_C;
+
+        // IO
+        s_req.ready = 1'b0;
+
+        m_req_int.valid = 1'b0;
+        m_req_int.data = s_req.data;
     end
 
 end

--- a/hw/hdl/user/mux_init/user_req_mux.sv
+++ b/hw/hdl/user/mux_init/user_req_mux.sv
@@ -122,7 +122,7 @@ always_comb begin
     user_remote_rd_int.data.req_2 = 0;
 
     user_remote_wr_int.data.req_1 = 0;
-    user_remote_wr_int.data.req_2 = user_sq_rd_int.data;
+    user_remote_wr_int.data.req_2 = user_sq_wr_int.data;
 end
 
 meta_reg #(.DATA_BITS($bits(req_t))) inst_reg_local_rd  (.aclk(aclk), .aresetn(aresetn), .s_meta(user_local_rd_int), .m_meta(user_local_rd));

--- a/scripts/wr_hdl/template_gen/lynx_pkg_tmplt.txt
+++ b/scripts/wr_hdl/template_gen/lynx_pkg_tmplt.txt
@@ -394,8 +394,8 @@ package lynxTypes;
     typedef struct packed {
         // Opcode
         logic [OPCODE_BITS-1:0] opcode; // One of the values of fpga::CoyoteOper
-        logic [STRM_BITS-1:0] strm;     // One of STRM_CARD, STRM_HOST, STRM_TCP, or STRM_RDMA
-        logic mode;
+        logic [STRM_BITS-1:0] strm;     // One of STRM_CARD, STRM_HOST, STRM_TCP, or STRM_RDMA (this determines the where this request lands)
+        logic mode;                     // In the STRM_RDMA case, controls whether to skip the request splitter in the dreq_rdma_parser_wr module
         logic rdma;
         logic remote;
 


### PR DESCRIPTION
## In short
I was unable to successfully request RDMA write transfers from my user logic. The symptom was wrong addresses and lengths were arriving on the `rq_wr` interface on the remote machine. This was apparently caused by a typo in the `user_req_mux` module, where the data from `sq_rd` was passed to the remote machine instead of data from `sq_wr`.

From user logic, RDMA write requests can now be sent via the `sq_wr` interface with correctly set `opcode`, `strm` and `mode` fields in the request struct (see below for more detail).

I have also added small comments, attempting to explain their use in a few words, to the `strm` and `mode` in the `lynx_pkg_tmplt.txt` file.

RDMA read requests have not been tested or examined.

## What I also found out
### The `mode` bit in the `req_t` structure
In the case of requests that aim to trigger an RDMA transder, the `mode` bit in the request structure controls how the request is passed along to the RDMA stack in the shell. If the `mode` bit is not set, then the request is split into possibly multiple requests, each of which is at most `PMTU` bytes in length. If the mode bit is set, the requests are passed along as is, without any splitting.
### Opcodes for RDMA transfers
The `dreq_rdma_parser_wr` module will act slightly differently according to the `opcode` value in the request structure. The valid values are called `APP_WRITE` and `APP_SEND`, with values `1` and `2` respectively. It appears that these must be set by the user logic for the request to arrive at the RDMA stack, instead of a value given from the `fpga::CoyoteOper[New?]` enum on the software side.
### The `rdma` and `remote` bits in the `req_t` structure
The `rdma` and `remote` bits in the request structure seem to not have any influence in this early part of the request path. In my design I have set both of them and found that the requests arrive on the remote end correctly, but I do not know if this is necessary.