### PR TITLE
Adding CMakeLists.txt to enable consuming Coyote as a library

### DIFF
--- a/sw/CMakeLists.txt
+++ b/sw/CMakeLists.txt
@@ -1,0 +1,188 @@
+#
+# Coyote SW package
+#
+cmake_minimum_required(VERSION 3.14)
+
+# Config
+set(EN_AVX "1" CACHE STRING "AVX enabled.")
+set(EN_GPU "0" CACHE STRING "GPU enabled.")
+set(CYT_LANG CXX)
+
+option(COYOTE_VERBOSE "Print verbose debug statements." OFF)
+
+if(COYOTE_VERBOSE) 
+  add_compile_definitions(VERBOSE)
+endif()
+
+if(EN_GPU)
+    if(NOT DEFINED ROCM_PATH)
+    if(DEFINED ENV{ROCM_PATH})
+        set(ROCM_PATH $ENV{ROCM_PATH} CACHE PATH "Path to which ROCM has been installed")
+    elseif(DEFINED ENV{HIP_PATH})
+        set(ROCM_PATH "$ENV{HIP_PATH}/.." CACHE PATH "Path to which ROCM has been installed")
+    else()
+        set(ROCM_PATH "/opt/rocm" CACHE PATH "Path to which ROCM has been installed")
+    endif()
+    endif()
+
+    file(STRINGS "${ROCM_PATH}/.info/version" ROCM_VERSION)
+    message("-- Found ROCm: ${ROCM_VERSION}")
+
+    if (NOT DEFINED CMAKE_CXX_COMPILER)
+        set(CMAKE_CXX_COMPILER ${ROCM_PATH}/bin/hipcc)
+    endif()
+
+    if(NOT DEFINED HIP_PATH)
+        if(NOT DEFINED ENV{HIP_PATH})
+            set(HIP_PATH "/opt/rocm/hip" CACHE PATH "Path to which HIP has been installed")
+        else()
+            set(HIP_PATH $ENV{HIP_PATH} CACHE PATH "Path to which HIP has been installed")
+        endif()
+    endif()
+
+    if(NOT DEFINED HCC_PATH)
+        if(DEFINED ENV{HCC_PATH})
+            set(HCC_PATH $ENV{HCC_PATH} CACHE PATH "Path to which HCC has been installed")
+        else()
+            set(HCC_PATH "${ROCM_PATH}/hcc" CACHE PATH "Path to which HCC has been installed")
+        endif()
+        set(HCC_HOME "${HCC_PATH}")
+    endif()
+
+    if(NOT DEFINED HIP_CLANG_PATH)
+        if(NOT DEFINED ENV{HIP_CLANG_PATH})
+            set(HIP_CLANG_PATH "${ROCM_PATH}/llvm/bin" CACHE PATH "Path to which HIP compatible clang binaries have been installed")
+        else()
+            set(HIP_CLANG_PATH $ENV{HIP_CLANG_PATH} CACHE PATH "Path to which HIP compatible clang binaries have been installed")
+        endif()
+    endif()
+
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${HIP_PATH}/cmake" )
+    list(APPEND CMAKE_PREFIX_PATH
+        "${HIP_PATH}/lib/cmake"
+        "${HIP_PATH}/../lib/cmake" # hopefully catches all extra HIP dependencies
+    )
+
+    find_package(HIP QUIET)
+    if(HIP_FOUND)
+        message(STATUS "Found HIP: " ${HIP_VERSION})
+    else()
+        message(FATAL_ERROR "Could not find HIP. Ensure that HIP is either installed in /opt/rocm/hip or the variable HIP_PATH is set to point to the right location.")
+    endif()
+    find_package(hip REQUIRED)
+
+    set(CYT_LANG ${CYT_LANG} HIP)
+endif()
+
+# Create a lib
+project(
+    coyote
+    VERSION 2.0.0
+    DESCRIPTION
+        "Coyote library"
+    LANGUAGES ${CYT_LANG}
+)
+set(CMAKE_DEBUG_POSTFIX d)
+
+# C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -march=native -O3")
+
+# Sources and includes
+file(GLOB CYT_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/src/*.cpp")
+set(CYT_INCLUDE_PATH ${CMAKE_CURRENT_LIST_DIR}/include)
+
+# Add shared
+add_library(coyote SHARED ${CYT_SOURCES})
+
+set_target_properties(coyote PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+)
+
+if (NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
+endif()
+
+if (NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
+endif()
+
+# Includes
+target_include_directories(coyote
+    PUBLIC
+        $<BUILD_INTERFACE:${CYT_INCLUDE_PATH}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/coyote>
+)
+target_link_directories(coyote PUBLIC /usr/local/lib)
+
+# Libs
+find_package(Boost COMPONENTS program_options REQUIRED)
+target_link_libraries(coyote PUBLIC ${Boost_LIBRARIES})
+
+# Comp
+if(EN_AVX)
+    target_compile_definitions(coyote PUBLIC EN_AVX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
+endif()
+if(EN_GPU)
+    target_compile_definitions(coyote PUBLIC EN_GPU)
+
+    # Include GPU directories
+    target_include_directories(coyote
+            PUBLIC
+                $<BUILD_INTERFACE:${ROCM_PATH}/include>
+                $<BUILD_INTERFACE:${ROCM_PATH}/include/hsa>)
+
+    # Add GPU libs
+    #set_target_properties(coyote PROPERTIES LINKER_LANGUAGE HIP)
+    target_link_libraries(coyote PUBLIC hip::device numa pthread drm drm_amdgpu rt dl hsa-runtime64 hsakmt)
+
+endif()
+
+# Add installation rules
+include(GNUInstallDirs)
+
+# Install the library
+install(TARGETS coyote
+    EXPORT CoyoteTargets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}            # for shared libraries (.so)
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}            # for static libraries (.a)
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}            # for executables
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}       # for headers
+)
+
+# Install headers
+install(DIRECTORY ${CYT_INCLUDE_PATH}/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/coyote
+    FILES_MATCHING PATTERN *.hpp
+)
+
+# Export package configuration
+install(EXPORT CoyoteTargets
+    FILE CoyoteTargets.cmake
+    NAMESPACE fpga::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/coyote
+)
+
+# Generate CMake package configuration files
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/CoyoteConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_LIST_DIR}/cmake/CoyoteConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/CoyoteConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/coyote
+)
+
+# Install CMake configuration files
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/CoyoteConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/CoyoteConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/coyote
+)

--- a/sw/cmake/CoyoteConfig.cmake.in
+++ b/sw/cmake/CoyoteConfig.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/CoyoteTargets.cmake")
+
+# Optionally include extra configuration variables or information
+set(Coyote_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")


### PR DESCRIPTION
## Description

As part of a master thesis, we are currently using Coyote to implement FPGA-based database operators. These operators will be integrated into the code base of an existing database. Therefore, we need to consume Coyote as a library from another C++ code base. This PR adds the CMake configurations that are required to consume Coyote as a library, because they have been missing up until now.

Once these changes are merged, one can build the /sw folder of Coyote as a library as follows:

```bash
git clone https://github.com/sven-weber/Coyote
pushd coyote/sw
pushd build
cmake_options=(
  "-DCMAKE_BUILD_TYPE=$build_type"
  "-DCMAKE_INSTALL_PREFIX=$dest"
  "-DCOYOTE_VERBOSE=OFF"
)
cmake "${cmake_options[@]}" ..
```

The majority of the ```CMakeLists.txt``` file has been copied from the existing ```CMakeLists.txt``` inside /cmake/FindCoyoteSW.cmake.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [x] Other

## Tests & Results
I tried to consume Coyote as a library with the steps described above and the changes proposed in this PR. This worked without problems!

### Checklist
- [N/A] I have commented my code and made corresponding changes to the documentation.
- [N/A] I have added tests/results that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings or errors & all tests successfully pass.