### PR TITLE
Moving set & getCSR from bThread header to implementation to prevent compiler errors

### DIFF
--- a/sw/include/bThread.hpp
+++ b/sw/include/bThread.hpp
@@ -161,9 +161,9 @@ public:
 	 * @param val : value to be written
 	 * @param offs : slave register offset
 	 */
-	inline auto setCSR(uint64_t val, uint32_t offs) { ctrl_reg[offs] = val; }
-	inline auto getCSR(uint32_t offs) { return ctrl_reg[offs]; }
-
+	void setCSR(uint64_t val, uint32_t offs);
+	uint64_t getCSR(uint32_t offs);
+	
 	/**
 	 * @brief Invoke a transfer of data 
 	 * coper - Coyote Operation (i.e. a LOCAL_WRITE or a REMOTE_RDMA_WRITE)

--- a/sw/src/bThread.cpp
+++ b/sw/src/bThread.cpp
@@ -328,6 +328,14 @@ void bThread::mmapFpga() {
 	}
 }
 
+void bThread::setCSR(uint64_t val, uint32_t offs) {
+    ctrl_reg[offs] = val; 
+}
+
+uint64_t bThread::getCSR(uint32_t offs) {
+    return ctrl_reg[offs];
+}
+
 /**
  * @brief Munmap vFPGA control plane
  * 


### PR DESCRIPTION
## Description

For my master thesis, I integrated the register-based configuration into my Coyote FPGA design. I then proceeded to try to write/read register values using the ```getCSR``` and ```setCSR``` methods offered by ```bThread```. However, doing so lead to a segmentation fault.

After some hours of debugging, I found the following problem:

The ```getCSR``` and ```setCSR``` methods rely on a memory-mapped region. This mapping is performed inside the ```bThread::mmapFpga()``` function where the ```ctrl_reg``` variable is set to point to the beginning of this memory region. Writing/Reading registers is then executed by reading from/writing to the address given by ```ctrl_reg```. This writing/reading is implement in the header file of the ```bThread``` class. However, with certain compiler settings/versions/kinds this can lead to problems. I compiled Coyote with gcc version 9.4.0 and clang version 10.0.0 that are available in the HACC cluster.

Probably due to a compiler bug, the address of the ```ctrl_reg``` was NOT correct when this field is accessed via a method implemented inside the the ```bThread``` header (e.g. ```getCSR``` and ```setCSR```) . To be precise, the address of ```ctrl_reg``` was shifted by 8 bytes (not the pointer ctrl_reg holds, but the address of the field itself!). The memory this field was then referencing was uninitialized in my case. Therefore, de-referencing the pointer ```ctrl_reg``` was supposed to hold, lead to a segmentation fault (due to ```ctrl_reg``` being NULL).

When using **gcc**, calling set/getCSR was still working fine inside the ```bThread``` header but broke as soon as the constructor finished (for example, when calling the same methods inside the ```cThread``` constructor or via ```cThread``` directly). Using **clang**, set/getCSR already broke inside the ```bThread``` constructor right after the ```bThread::mmapFpga()``` call finished.

This issue could be mitigated by:

1. Adding a field right before the ```ctrl_reg```
2. Incrementing the address of the ```ctrl_reg``` field by 8 before performing the de-referencing inside ```getCSR``` and ```setCSR```
3. Moving the implementation from the ```bThread.hpp``` header to its implementation ```bThread.cpp```

As it is best practice to have implementations inside the implementation and not the header, this PR provides the changes for the third mitigation to prevent similar problems in the future. With this mitigation, all addresses were correct again and everything worked as expected.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results
I tested these changes on my Coyote project were they lead to registers now working properly!

### Checklist
- [x] I have commented my code and made corresponding changes to the documentation.
- [x] I have added tests/results that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings or errors & all tests successfully pass.

I did not run any tests besides the one mentioned above. Unfortunately, I would not find instructions on how to run further tests (maybe I am blind). If you could give me guidance on which additional tests to run I am happy to run them as well!
