### PR TITLE
Fixing interrupt values for user-specified isr which broke due to kernel API change

### DIFF
--- a/driver/include/coyote_defs.h
+++ b/driver/include/coyote_defs.h
@@ -336,7 +336,7 @@ extern bool en_hmm;
 #define IOCTL_SHELL_XDMA_STATS _IOR('F', 16, unsigned long)
 #define IOCTL_SHELL_NET_STATS _IOR('F', 17, unsigned long)
 #define IOCTL_SET_NOTIFICATION_PROCESSED _IOR('F', 18, unsigned long)
-#define IOCTL_GET_INTERRUPT_VALUE _IOR('F', 19, unsigned long)
+#define IOCTL_GET_NOTIFICATION_VALUE _IOR('F', 19, unsigned long)
 
 // Reconfiguration IOCTL calls; see reconfig_ops.c for more details
 #define IOCTL_ALLOC_HOST_RECONFIG_MEM _IOW('P', 1, unsigned long)

--- a/driver/include/coyote_defs.h
+++ b/driver/include/coyote_defs.h
@@ -336,6 +336,7 @@ extern bool en_hmm;
 #define IOCTL_SHELL_XDMA_STATS _IOR('F', 16, unsigned long)
 #define IOCTL_SHELL_NET_STATS _IOR('F', 17, unsigned long)
 #define IOCTL_SET_NOTIFICATION_PROCESSED _IOR('F', 18, unsigned long)
+#define IOCTL_GET_INTERRUPT_VALUE _IOR('F', 19, unsigned long)
 
 // Reconfiguration IOCTL calls; see reconfig_ops.c for more details
 #define IOCTL_ALLOC_HOST_RECONFIG_MEM _IOW('P', 1, unsigned long)
@@ -728,6 +729,9 @@ extern struct eventfd_ctx *user_notifier[MAX_N_REGIONS][N_CTID_MAX];
 
 /// Interrupt locks, ensuring that only one interrupt (per vFPGA and cThread) is processed at a time and that the user space can safely read/write to the eventfd context
 extern struct mutex user_notifier_lock[MAX_N_REGIONS][N_CTID_MAX];
+
+/// Interrupt values used to pass values between vpfga_isr and vpfga_ops
+extern int32_t interrupt_value[MAX_N_REGIONS][N_CTID_MAX];
 
 #ifdef HMM_KERNEL
 extern struct list_head migrated_pages[MAX_N_REGIONS][N_CTID_MAX];

--- a/driver/src/vfpga/vfpga_ops.c
+++ b/driver/src/vfpga/vfpga_ops.c
@@ -551,11 +551,31 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
         case IOCTL_SET_NOTIFICATION_PROCESSED:
             ret_val = copy_from_user(&tmp, (unsigned long *) arg, sizeof(unsigned long));
             if (ret_val != 0) {
-                pr_warn("user data could not be coppied, return %d\n", ret_val);
+                pr_warn("user data could not be copied, return %d\n", ret_val);
             } else {
                 int32_t ctid = (int32_t) tmp[0];
                 dbg_info("marking notification with vfpga ID %d, ctid %d as processed\n", device->id, ctid);
                 mutex_unlock(&user_notifier_lock[device->id][ctid]);
+            }
+            break;
+        
+        // Returns the interrupt value to the user-space process. This happens as a reaction to a evenfd write.
+        // See vfpga_isr.c for details.
+        case IOCTL_GET_INTERRUPT_VALUE:
+            // This ioctl does a read & write.
+            // 1. retrieve the ctid from the user-space process.
+            ret_val = copy_from_user(&tmp, (unsigned long *) arg, sizeof(unsigned long));
+            if (ret_val != 0) {
+                pr_warn("user data could not be copied, return %d\n", ret_val);
+            } else {
+                // 2. send the interrupt value for this ctid!
+                int32_t ctid = (int32_t) tmp[0];
+                dbg_info("retrieving interrupt value for vfpga ID %d, ctid %d\n", device->id, ctid);
+                tmp[0] = interrupt_value[device->id][ctid];
+                ret_val = copy_to_user((unsigned long *) arg, &tmp, sizeof(uint32_t));
+                if (ret_val != 0) {
+                    pr_warn("could not copy data to user space, return %d\n", ret_val);
+                }
             }
             break;
 

--- a/driver/src/vfpga/vfpga_ops.c
+++ b/driver/src/vfpga/vfpga_ops.c
@@ -561,7 +561,7 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
         
         // Returns the interrupt value to the user-space process. This happens as a reaction to a evenfd write.
         // See vfpga_isr.c for details.
-        case IOCTL_GET_INTERRUPT_VALUE:
+        case IOCTL_GET_NOTIFICATION_VALUE:
             // This ioctl does a read & write.
             // 1. retrieve the ctid from the user-space process.
             ret_val = copy_from_user(&tmp, (unsigned long *) arg, sizeof(unsigned long));

--- a/driver/src/vfpga/vfpga_uisr.c
+++ b/driver/src/vfpga/vfpga_uisr.c
@@ -33,6 +33,10 @@ struct eventfd_ctx *user_notifier[MAX_N_REGIONS][N_CTID_MAX];
 /// Every time a user interrupt is issued, the mutex is locked, avoiding race conditions until the interrupt has been handled
 struct mutex user_notifier_lock[MAX_N_REGIONS][N_CTID_MAX];
 
+/// List of values that have been set for a interrupt for a vFPGA and Coyote thread.
+/// Values are set in vfpga_isr and read in vfpga_ops via ioctl.
+int32_t interrupt_value[MAX_N_REGIONS][N_CTID_MAX];
+
 int vfpga_register_eventfd(struct vfpga_dev *device, int ctid, int eventfd) {
     int ret_val = 0;
     BUG_ON(!device);

--- a/sw/include/cDefs.hpp
+++ b/sw/include/cDefs.hpp
@@ -89,7 +89,7 @@ namespace coyote {
 #define IOCTL_NET_STATS                     _IOR('F', 17, unsigned long)
 
 #define IOCTL_SET_NOTIFICATION_PROCESSED    _IOR('F', 18, unsigned long)
-#define IOCTL_GET_INTERRUPT_VALUE           _IOR('F', 19, unsigned long)
+#define IOCTL_GET_NOTIFICATION_VALUE        _IOR('F', 19, unsigned long)
 
 #define IOCTL_ALLOC_HOST_RECONFIG_MEM       _IOW('P', 1, unsigned long)
 #define IOCTL_FREE_HOST_RECONFIG_MEM        _IOW('P', 2, unsigned long)

--- a/sw/include/cDefs.hpp
+++ b/sw/include/cDefs.hpp
@@ -89,6 +89,7 @@ namespace coyote {
 #define IOCTL_NET_STATS                     _IOR('F', 17, unsigned long)
 
 #define IOCTL_SET_NOTIFICATION_PROCESSED    _IOR('F', 18, unsigned long)
+#define IOCTL_GET_INTERRUPT_VALUE           _IOR('F', 19, unsigned long)
 
 #define IOCTL_ALLOC_HOST_RECONFIG_MEM       _IOW('P', 1, unsigned long)
 #define IOCTL_FREE_HOST_RECONFIG_MEM        _IOW('P', 2, unsigned long)

--- a/sw/src/bThread.cpp
+++ b/sw/src/bThread.cpp
@@ -78,7 +78,7 @@ int eventHandler(int fd, int efd, int terminate_efd, void(*uisr)(int), int32_t c
                 // implementation infeasible from the coyote driver perspective.
                 // Read the comments in driver/fpga_isr.c, function 'vfpga_notify_handler' for further details.
                 tmp[0] = ctid;
-                if (ioctl(fd, IOCTL_GET_INTERRUPT_VALUE, &tmp)) {
+                if (ioctl(fd, IOCTL_GET_NOTIFICATION_VALUE, &tmp)) {
                     throw std::runtime_error("driver could get value for notification");
                 }
                 uint32_t isr_val = tmp[0];
@@ -88,7 +88,7 @@ int eventHandler(int fd, int efd, int terminate_efd, void(*uisr)(int), int32_t c
                 // Call the user interrupt function!
 				uisr(isr_val);
                 
-                // Set the noficition as processed!
+                // Set the notification as processed!
                 tmp[0] = ctid;
                 if (ioctl(fd, IOCTL_SET_NOTIFICATION_PROCESSED, &tmp)) {
                     throw std::runtime_error("driver could not mark user notification as processed");


### PR DESCRIPTION
## Description
> :memo: This PR introduces a fix for propagating interrupt values from the coyote kernel driver to the user-space program. Propagating these values broke for Linux kernel versions >= 6.8 due to a change in the kernel API.

The new proposed way to propagate the values is to use the existing eventfd only to notify the user-space program of a interrupt. The program then fetches the value via the established ioctl routines from the driver.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results
> :memo: I tested the correct behavior of the new implementation via the example 4 from the coyote repository.

Before the change, the output of the program would be:

```console
I am now starting a data transfer which will cause an interrupt...
Hello from my interrupt callback! The interrupt received a value: 1
I am now starting a data transfer which shouldn't cause an interrupt...
And, as promised, there was no interrupt!
```

With this change, the program now properly prints the interrupt value:

```console
I am now starting a data transfer which will cause an interrupt...
Hello from my interrupt callback! The interrupt received a value: 73
I am now starting a data transfer which shouldn't cause an interrupt...
And, as promised, there was no interrupt!
```

### Checklist
- [x] I have commented my code and made corresponding changes to the documentation.
- [x] I have added tests/results that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings or errors & all tests successfully pass.
