### PR TITLE
[bugfix] remove sleep_for when polling from completion

### DIFF
--- a/examples/01_hello_world/sw/src/main.cpp
+++ b/examples/01_hello_world/sw/src/main.cpp
@@ -74,9 +74,7 @@ double run_bench(
         }
 
         // Wait until all of them are finished; short sleep to avoid busy-waiting
-        while (coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_TRANSFER) != transfers) {
-            std::this_thread::sleep_for(std::chrono::nanoseconds(50));
-        }
+        while (coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_TRANSFER) != transfers) {}
     };
 
     bench.execute(bench_fn, prep_fn);

--- a/examples/02_hls_vadd/sw/src/main.cpp
+++ b/examples/02_hls_vadd/sw/src/main.cpp
@@ -79,9 +79,7 @@ int main(int argc, char *argv[]) {
     while (
         coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_WRITE) != 1 || 
         coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_READ) != 2
-    ) {
-        std::this_thread::sleep_for(std::chrono::nanoseconds(50));
-    }
+    ) {}
 
     // Verify correctness of the results
     for (int i = 0; i < size; i++) { assert(a[i] + b[i] == c[i]); }

--- a/examples/04_user_interrupts/sw/src/main.cpp
+++ b/examples/04_user_interrupts/sw/src/main.cpp
@@ -62,9 +62,7 @@ int main(int argc, char *argv[])  {
     coyote_thread.invoke(coyote::CoyoteOper::LOCAL_READ, sg);
 
     // Poll on completion of the transfer & once complete, clear
-    while (!coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_READ)) {
-        std::this_thread::sleep_for(std::chrono::nanoseconds(50));
-    }
+    while (!coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_READ)) {}
     coyote_thread.clearCompleted();
 
     // Short delay for demonstration purposes; keeps the two cases separate and the output readable
@@ -74,9 +72,7 @@ int main(int argc, char *argv[])  {
     data[0] = 1024;
     std::cout << "I am now starting a data transfer which shouldn't cause an interrupt..." << std::endl;
     coyote_thread.invoke(coyote::CoyoteOper::LOCAL_READ, sg);
-    while (!coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_READ)) {
-        std::this_thread::sleep_for(std::chrono::nanoseconds(50));
-    }
+    while (!coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_READ)) {}
     coyote_thread.clearCompleted();
     std::cout << "And, as promised, there was no interrupt!" << std::endl << std::endl;
 

--- a/examples/05_reconfigure_shell/sw/src/main.cpp
+++ b/examples/05_reconfigure_shell/sw/src/main.cpp
@@ -71,9 +71,7 @@ void run_hls_vadd() {
     while (
         coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_WRITE) != 1 || 
         coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_READ) != 2
-    ) {
-        std::this_thread::sleep_for(std::chrono::nanoseconds(50));
-    }
+    ) {}
 
     for (int i = 0; i < VECTOR_ELEMENTS; i++) { assert(a[i] + b[i] == c[i]); }
     std::cout << "HLS Vector Addition completed successfully!" << std::endl << std::endl;
@@ -97,9 +95,7 @@ void run_user_interrupts() {
     std::cout << "I am now starting a data transfer which will cause an interrupt..." << std::endl;
     coyote_thread.invoke(coyote::CoyoteOper::LOCAL_READ, sg);
 
-    while (!coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_READ)) {
-        std::this_thread::sleep_for(std::chrono::nanoseconds(50));
-    }
+    while (!coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_READ)) {}
     coyote_thread.clearCompleted();
 
     // Short delay, to avoid triggering the reconfiguration before the interrupt has been processed

--- a/examples/06_gpu_p2p/sw/src/main.cpp
+++ b/examples/06_gpu_p2p/sw/src/main.cpp
@@ -77,9 +77,7 @@ double run_bench(
         }
 
         // Wait until all of them are finished
-        while (coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_TRANSFER) != transfers) {
-            std::this_thread::sleep_for(std::chrono::nanoseconds(50));
-        }
+        while (coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_TRANSFER) != transfers) {}
     };
 
     bench.execute(bench_fn, prep_fn);

--- a/examples/07_perf_fpga/sw/src/main.cpp
+++ b/examples/07_perf_fpga/sw/src/main.cpp
@@ -82,9 +82,7 @@ double run_bench(
         coyote_thread.setCSR(static_cast<uint64_t>(oper), static_cast<uint32_t>(BenchmarkRegisters::CTRL_REG));
         
         // Wait until done register is asserted high
-        while (!coyote_thread.getCSR(static_cast<uint32_t>(BenchmarkRegisters::DONE_REG))) {
-            std::this_thread::sleep_for(std::chrono::nanoseconds(50));
-        }
+        while (!coyote_thread.getCSR(static_cast<uint32_t>(BenchmarkRegisters::DONE_REG))) {}
 
         // Read from time register and convert to ns
         return (double) coyote_thread.getCSR(static_cast<uint32_t>(BenchmarkRegisters::TIMER_REG)) * (double) CLOCK_PERIOD_NS;

--- a/examples/09_perf_rdma/sw/src/client/main.cpp
+++ b/examples/09_perf_rdma/sw/src/client/main.cpp
@@ -67,9 +67,7 @@ double run_bench(
             coyote_thread.invoke(coyote_operation, sg);
         }
 
-        while (coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_WRITE) != transfers) {
-            std::this_thread::sleep_for(std::chrono::nanoseconds(50));
-        }
+        while (coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_WRITE) != transfers) {}
     };
 
     // Execute benchmark

--- a/examples/09_perf_rdma/sw/src/server/main.cpp
+++ b/examples/09_perf_rdma/sw/src/server/main.cpp
@@ -55,9 +55,7 @@ void run_bench(
 
         // For writes, wait until client has written the targer number of messages; then write them back
         if (operation) {
-            while (coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_WRITE) != transfers) {
-                std::this_thread::sleep_for(std::chrono::nanoseconds(50));
-            }
+            while (coyote_thread.checkCompleted(coyote::CoyoteOper::LOCAL_WRITE) != transfers) {}
 
             for (int i = 0; i < transfers; i++) {
                 coyote_thread.invoke(coyote::CoyoteOper::REMOTE_RDMA_WRITE, sg);

--- a/examples/10_app_reconfiguration/sw/src/server/main.cpp
+++ b/examples/10_app_reconfiguration/sw/src/server/main.cpp
@@ -77,9 +77,7 @@ int main(int argc, char *argv[]) {
             while (
                 coyote_thread->checkCompleted(coyote::CoyoteOper::LOCAL_WRITE) != 1 || 
                 coyote_thread->checkCompleted(coyote::CoyoteOper::LOCAL_READ) != 2
-            ) {
-                std::this_thread::sleep_for(std::chrono::nanoseconds(50));
-            }
+            ) {}
             
             // Same as above; the memory addresses can be explicitly unmapped, but this is not necessary
             // If left out, the Coyote thread will automatically unmap the memory when it is no longer needed
@@ -130,9 +128,7 @@ int main(int argc, char *argv[]) {
             while (
                 coyote_thread->checkCompleted(coyote::CoyoteOper::LOCAL_WRITE) != 1 || 
                 coyote_thread->checkCompleted(coyote::CoyoteOper::LOCAL_READ) != 2
-            ) {
-                std::this_thread::sleep_for(std::chrono::nanoseconds(50));
-            }
+            ) {}
             coyote_thread->clearCompleted();
 
             auto end_time = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION

## Description
> :memo: sleep_for provides no guarantees on how long it will actually sleep for. When polling for completion, this can cause performance issue for small transfers; e.g., in the 1st example, small messages take ~3 - 5us to complete without the sleep while with a sleep they take ~50us. 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

### Checklist
- [x] I have commented my code and made corresponding changes to the documentation.
- [x] I have added tests/results that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings or errors & all tests successfully pass.
