### PR TITLE
Testbench: BugFix in Python unit-tests io_writer

### DIFF
--- a/sim/unit_test/io_writer.py
+++ b/sim/unit_test/io_writer.py
@@ -443,7 +443,8 @@ class SimulationIOWriter:
                     written = input_file.write(chunk)
                     bytes_written += written
                     input_file.flush()
-                except BlockingIOError:
+                except BlockingIOError as e:
+                    bytes_written += e.characters_written
                     stop_event.wait(0.1)
                 except:
                     print("FAILED TO WRITE SIMULATION INPUT")


### PR DESCRIPTION
## Description
> :memo: In the python unit-test implementation there is a bug: When writing to the named-pipe for the input into the SV testbench, we already considered that the writing may block. However, when this happens, some bytes may have already written to the file before the file blocked. The [BlockingIOError](https://docs.python.org/3/library/exceptions.html#BlockingIOError) tells us how many bytes have been written, which was not considered up until now. This PR adds support for this case to the io_writer.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results
> :memo: I created a test case with large input that failed before this change and now works. Additionally, I ran a set of existing tests that continued working fine.

### Checklist
- [x] I have commented my code and made corresponding changes to the documentation.
- [x] I have added tests/results that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings or errors & all tests successfully pass.
