### PR TITLE
Add instance name for register slices

### DIFF
--- a/hw/hdl/common/regs/axi_reg.sv
+++ b/hw/hdl/common/regs/axi_reg.sv
@@ -37,7 +37,7 @@ module axi_reg (
 	AXI4.m			    m_axi
 );
 
-    axi_register_slice_512 (
+    axi_register_slice_512 inst_reg_slice (
         .aclk(aclk),
         .aresetn(aresetn),
         .s_axi_awid(s_axi.awid),

--- a/hw/hdl/common/regs/axil_reg.sv
+++ b/hw/hdl/common/regs/axil_reg.sv
@@ -37,7 +37,7 @@ module axil_reg (
 	AXI4L.m			m_axi
 );
 
-axil_register_slice (
+axil_register_slice inst_reg_slice (
     .aclk(aclk),
     .aresetn(aresetn),
     .s_axi_awaddr(s_axi.awaddr),

--- a/hw/hdl/common/regs/axim_reg.sv
+++ b/hw/hdl/common/regs/axim_reg.sv
@@ -37,7 +37,7 @@ module axim_reg (
 	AXI4.m			    m_axi
 );
 
-axim_register_slice (
+axim_register_slice inst_reg_slice (
     .aclk(aclk),
     .aresetn(aresetn),
     .s_axi_awid(s_axi.awid),


### PR DESCRIPTION
## Description
> :memo: The missing name can cause elaboration to fail in some cases, especially during simulation.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

### Checklist
- [x] I have commented my code and made corresponding changes to the documentation.
- [x] I have added tests/results that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings or errors & all tests successfully pass.
