### PR TITLE
sim: wait until all output FIFO data has been consumed

### DIFF
--- a/sim/unit_test/io_writer.py
+++ b/sim/unit_test/io_writer.py
@@ -139,6 +139,8 @@ class SimulationIOWriter:
         self.output_thread = SafeThread(self._read_simulation_output_entry)
         self.output_thread.start()
 
+        self.output_fd = None
+
     def __del__(self):
         self.terminate_io_threads()
 
@@ -384,6 +386,8 @@ class SimulationIOWriter:
             if not fd:
                 return
 
+            self.output_fd = fd
+
             # In case of the output file, we can open the pipe as a reader immediately.
             # However, the pipe will only return EOF until no writer is connected to is.
             # Connecting a writer can take some time since the simulation needs to be started
@@ -403,6 +407,7 @@ class SimulationIOWriter:
         finally:
             # Delete the pipe again!
             os.remove(file_path)
+            self.output_fd = None
 
     def _any_event_set(self, *events: List[threading.Event]):
         if events:


### PR DESCRIPTION
## Description
Wait for the output FIFO to be empty before terminating the Vivado thread, as this thread in turns terminates all IOWriter threads, possibly before all the output has been read.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results
Ran a unit test with a design with a higher-than-usual latency several times. Without this fix, the unit test would fail most of the times.

### Checklist
- [x] I have commented my code and made corresponding changes to the documentation.
- [ ] I have added tests/results that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings or errors & all tests successfully pass.
