### PR TITLE
Fix uninitialized values in one-sided operations

### DIFF
--- a/sw/src/cThread.cpp
+++ b/sw/src/cThread.cpp
@@ -626,10 +626,8 @@ void cThread::invoke(CoyoteOper oper, localSg sg, bool last) {
     }
 
     // Trigger the operation
-    uint64_t addr_cmd_src, addr_cmd_dst;
-    uint64_t ctrl_cmd_src, ctrl_cmd_dst;
     if (oper == CoyoteOper::LOCAL_READ) {
-        ctrl_cmd_src =
+        uint64_t ctrl_cmd_src =
             ((ctid & CTRL_PID_MASK) << CTRL_PID_OFFS) |
             ((sg.dest & CTRL_DEST_MASK) << CTRL_DEST_OFFS) |
             (last ? CTRL_LAST : 0x0) |
@@ -638,12 +636,12 @@ void cThread::invoke(CoyoteOper oper, localSg sg, bool last) {
             (0x0) | 
             (static_cast<uint64_t>(sg.len) << CTRL_LEN_OFFS);
         
-        addr_cmd_src = reinterpret_cast<uint64_t>(sg.addr);
+        uint64_t addr_cmd_src = reinterpret_cast<uint64_t>(sg.addr);
 
-        postCmd(addr_cmd_dst, ctrl_cmd_dst, addr_cmd_src, ctrl_cmd_src);
+        postCmd(0, 0, addr_cmd_src, ctrl_cmd_src);
 
     } else if (oper == CoyoteOper::LOCAL_WRITE) {
-        ctrl_cmd_dst =
+        uint64_t ctrl_cmd_dst =
             ((ctid & CTRL_PID_MASK) << CTRL_PID_OFFS) |
             ((sg.dest & CTRL_DEST_MASK) << CTRL_DEST_OFFS) |
             (last ? CTRL_LAST : 0x0) |
@@ -652,9 +650,9 @@ void cThread::invoke(CoyoteOper oper, localSg sg, bool last) {
             (0x0) | 
             (static_cast<uint64_t>(sg.len) << CTRL_LEN_OFFS);
 
-        addr_cmd_dst = reinterpret_cast<uint64_t>(sg.addr);
+        uint64_t addr_cmd_dst = reinterpret_cast<uint64_t>(sg.addr);
 
-        postCmd(addr_cmd_dst, ctrl_cmd_dst, addr_cmd_src, ctrl_cmd_src);
+        postCmd(addr_cmd_dst, ctrl_cmd_dst, 0, 0);
 
     } else {
         std::cerr << "ERROR: cThread::invoke() called with an unsupported operation type; returning..." << std::endl;


### PR DESCRIPTION
## Description
> :memo: This PR explicitly initializes the value of src/dst in LOCAL_WRITE/LOCAL_READ operations. If unitialized, they _may_ be equal to zero, which is the correct case. However, depending on the compiler (and the flags), these may also be non-zero, leading to issuing transfers that aren't requested.

## Type of change
- [x] Bug fix

## Tests & Results
> :memo: One can confirm that with the old code, _Example 2: HLS Vector Addition_ stalls when removing -O3 from cmake/FindCoyoteSW.cmake, as the number of completed reads is equal to 3, rather than 2. 

### Checklist
- [x] I have commented my code and made corresponding changes to the documentation.
- [x] I have added tests/results that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings or errors & all tests successfully pass.
