### PR TITLE
fix typo in RDMA mbx for simulation

### DIFF
--- a/sim/hw/tb_user.sv
+++ b/sim/hw/tb_user.sv
@@ -142,7 +142,7 @@ module tb_user;
     c_axisr rdma_rrsp_recv_drv[N_RDMA_AXI];
     c_axisr rdma_rrsp_send_drv[N_RDMA_AXI];
 
-    mem_mock #(N_CARD_AXI) rdma_mem_mock;
+    mem_mock #(N_RDMA_AXI) rdma_mem_mock;
 `endif
 
     memory_simulation mem_sim;


### PR DESCRIPTION
Follow up to #146.

Fixes a leftover typo that would generate the wrong number of mailboxes for RDMA-related stream simulation.
This issue is not noticeable unless more than one 1 RDMA stream is used.