### PR TITLE
Fix sw compilation when debugging is enabled

### DIFF
--- a/sw/include/cConn.hpp
+++ b/sw/include/cConn.hpp
@@ -160,7 +160,7 @@ public:
         std::vector<char> tmp = tasks[tid]->getRetVal();
         memcpy(&ret_val, tmp.data(), sizeof(ret));
 
-        DBG1("cConn: Request completed; return code" << ret_code << " return value: " << val); 
+        DBG1("cConn: Request completed; return code" << ret_code << " return value: " << ret_val); 
         return ret_val;
     }
 
@@ -248,7 +248,7 @@ public:
         std::vector<char> tmp = tasks[tid]->getRetVal();
         memcpy(&ret_val, tmp.data(), sizeof(ret));
 
-        DBG1("cConn: Request completed; return code" << ret_code << " return value: " << val); 
+        DBG1("cConn: Request completed; return code" << ret_code << " return value: " << ret_val); 
         return ret_val;
 
     }


### PR DESCRIPTION
Solves this issue which arises when compiling `sw/` using debug define `COYOTE_VERBOSE_DEBUG_1`:

```
In file included from /pub/scratch/ltagliavini/coyote/sw/include/cThread.hpp:58,
                 from /pub/scratch/ltagliavini/coyote/sw/include/cTask.hpp:34,                                                                                                                                                                                                   
                 from /pub/scratch/ltagliavini/coyote/sw/include/cConn.hpp:38,
                 from /pub/scratch/ltagliavini/coyote/sw/src/cConn.cpp:27:      
/pub/scratch/ltagliavini/coyote/sw/include/cConn.hpp: In member function ‘ret coyote::cConn::task(int32_t, args ...)’:                                                                                                                                                           
/pub/scratch/ltagliavini/coyote/sw/include/cConn.hpp:163:90: error: ‘val’ was not declared in this scope                                
  163 |         DBG1("cConn: Request completed; return code" << ret_code << " return value: " << val);
      |                                                                                          ^~~                  
/pub/scratch/ltagliavini/coyote/sw/include/cDefs.hpp:426:37: note: in definition of macro ‘DBG1’        
  426 | #define DBG1(msg) do { std::cout << msg << std::endl; } while ( false )                       
      |                                     ^~~                                                                                                                                                                                                                                  
/pub/scratch/ltagliavini/coyote/sw/include/cConn.hpp: In member function ‘ret coyote::cConn::getTaskReturnValue(int32_t)’:
/pub/scratch/ltagliavini/coyote/sw/include/cConn.hpp:251:90: error: ‘val’ was not declared in this scope
  251 |         DBG1("cConn: Request completed; return code" << ret_code << " return value: " << val);                                  
      |                                                                                          ^~~                                                                                                                                                                             
/pub/scratch/ltagliavini/coyote/sw/include/cDefs.hpp:426:37: note: in definition of macro ‘DBG1’        
  426 | #define DBG1(msg) do { std::cout << msg << std::endl; } while ( false )                       
      |                                     ^~~                                                                                         
```