### PR TITLE
Fix for simulation cThread issue with global variables

### DIFF
--- a/sim/sw/include/BinaryInputWriter.hpp
+++ b/sim/sw/include/BinaryInputWriter.hpp
@@ -95,7 +95,7 @@ class BinaryInputWriter {
 public:
     BinaryInputWriter() {}
 
-    ~BinaryInputWriter() {};
+    ~BinaryInputWriter() {}
 
     int open(const char *file_name) {
         fp = fopen(file_name, "wb");

--- a/sim/sw/include/Common.hpp
+++ b/sim/sw/include/Common.hpp
@@ -72,23 +72,6 @@ typedef struct {
     int status;
 } return_t;
 
-BlockingQueue<return_t> return_queue;
-
-int executeUnlessCrash(const std::function<void()> &lambda) {
-    auto other_thread = std::thread([&lambda]{
-        lambda();
-        return_queue.push({OTHER_THREAD_ID, 0});
-    });
-
-    auto result = return_queue.pop();
-    if (result.id != OTHER_THREAD_ID) { // VivadoRunner or OutputReader crashed
-        FATAL("Thread with id " << (int) result.id << " crashed")
-        std::terminate();
-    }
-    other_thread.join();
-    return result.status;
-}
-
 }
 
 #endif

--- a/sw/include/cThread.hpp
+++ b/sw/include/cThread.hpp
@@ -376,6 +376,15 @@ public:
 	/// Utility function, prints stats about this cThread including the number of commands invalidations etc.
 	void printDebug() const;
 
+private:
+    // We use this "pointer to implementation" pattern here to be able to attach additional state to
+    // the cThread in the simulation implementation of cThread. Before doing this, we had to use 
+    // global variables which caused issues with order of destruction potentially destroying the 
+    // simulation threads before they were joined. This is the minimally invasive way of doing this
+    // to be able to have a second implementation of cThread without duplicating the cThread 
+    // header.
+    class AdditionalState;
+    std::unique_ptr<AdditionalState> additional_state;
 };
 
 }

--- a/sw/src/cThread.cpp
+++ b/sw/src/cThread.cpp
@@ -105,7 +105,8 @@ static unsigned seed = std::chrono::system_clock::now().time_since_epoch().count
 
 cThread::cThread(int32_t vfid, pid_t hpid, uint32_t device, std::function<void(int)> uisr):
   hpid(hpid), vfid(vfid),
-  vlock(boost::interprocess::open_or_create, ("mutex_dev_" + std::to_string(device) + "_vfpa_" + std::to_string(vfid)).c_str()) {
+  vlock(boost::interprocess::open_or_create, ("mutex_dev_" + std::to_string(device) + "_vfpa_" + std::to_string(vfid)).c_str()),
+  additional_state(nullptr) {
 	DBG1("cThread: opening vFPGA " << vfid << ", hpid " << hpid);
 
 	// Open char device with the name specified in the driver
@@ -1214,5 +1215,8 @@ void cThread::printDebug() const {
 
 	std::cout << std::endl;
 }
+
+// Empty additional state class because we only need this for the simulation environment.
+class cThread::AdditionalState {};
 
 }


### PR DESCRIPTION
## Description
I've added additional state to the cThread definition and moved all previously global simulation state into that additional state class. This get's rid of problems with destruction order of global variables and possibly many other issues.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results
I've tested these changes in simulation and for the software library.

