### PR TITLE
Bug fix: enable invoke with only card stream & clean-up from PR #137

### DIFF
--- a/sim/sw/src/cThread.cpp
+++ b/sim/sw/src/cThread.cpp
@@ -472,6 +472,8 @@ int32_t cThread::getCtid() const { return ctid; };
 
 pid_t  cThread::getHpid() const { return hpid; };
 
+ibvQp* cThread::getQpair() const { return qpair.get(); }
+
 void cThread::printDebug() const {
     std::cout << std::setw(35) << "Sent local reads: \t-" << std::endl;
     std::cout << std::setw(35) << "Sent local writes: \t-" << std::endl;

--- a/sw/include/cThread.hpp
+++ b/sw/include/cThread.hpp
@@ -373,7 +373,10 @@ protected:
 
 	/// Getter: Host process ID (hpid)
 	pid_t getHpid() const;
-	inline auto getQpair() { return qpair.get(); }
+
+	/// Getter: queue pair (QP)
+	ibvQp* getQpair() const;
+	
 	/// Utility function, prints stats about this cThread including the number of commands invalidations etc.
 	void printDebug() const;
 

--- a/sw/src/cThread.cpp
+++ b/sw/src/cThread.cpp
@@ -620,7 +620,7 @@ void cThread::invoke(CoyoteOper oper, localSg sg, bool last) {
         throw std::runtime_error("ERROR: cThread::invoke() called with localSg flags, but the operation is not a LOCAL_READ or LOCAL_WRITE; exiting...");
     }
 
-    if (!fcnfg.en_strm) {
+    if (!fcnfg.en_strm && !fcnfg.en_mem) {
         throw std::runtime_error("ERROR: cThread::invoke() called for a local operation, but the shell was not synthesized with streams from host memory, exiting...");
     }
 
@@ -675,7 +675,7 @@ void cThread::invoke(CoyoteOper oper, localSg src_sg, localSg dst_sg, bool last)
         throw std::runtime_error("ERROR: cThread::invoke() called with two localSg flags, but the operation is not a LOCAL_TRANSFER; exiting...");
     }
 
-    if (!fcnfg.en_strm) {
+    if (!fcnfg.en_strm && !fcnfg.en_mem) {
         throw std::runtime_error("ERROR: cThread::invoke() called for a local operation but the shell was not synthesized with streams from host memory, exiting...");
     }
 
@@ -1185,6 +1185,8 @@ int32_t cThread::getCtid() const { return ctid; };
 
 pid_t  cThread::getHpid() const { return hpid; };
 
+ibvQp* cThread::getQpair() const { return qpair.get(); }
+	
 void cThread::printDebug() const {
 	std::cout << "-- STATISTICS - ID: cThread ID" << ctid << ", vFPGA ID" << vfid << std::endl;
 	std::cout << "-----------------------------------------------" << std::endl;


### PR DESCRIPTION
## Description
> :memo: Coyote can be synthesised with no host-to-vFPGA steams (i.e. EN_STRM = 0). While this is perfectly fine from a HW perspective, the software will not allow the invoke function to be called fro memory requests. This PR fixes it, in addition to a minor clean-up of the last PR to be merged, #137.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

### Checklist
- [x] I have commented my code and made corresponding changes to the documentation.
- [x] I have added tests/results that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings or errors & all tests successfully pass.
