### PR TITLE
Fixed CSR reads in simulation

### DIFF
--- a/sim/hw/ctrl_simulation.svh
+++ b/sim/hw/ctrl_simulation.svh
@@ -53,7 +53,13 @@ class ctrl_simulation;
         logic [AXIL_DATA_BITS-1:0] read_data;
 
         forever begin
-            mbx.get(trs);
+            // We need this as non-blocking with @(...), otherwise timing might be off if we do a 
+            // busy wait and we would need to wait an additional cycle every time
+            int success = mbx.try_get(trs);
+            while (!success) begin
+                @(drv.axi.cbm);
+                success = mbx.try_get(trs);
+            end
 
             if (trs.is_write) begin // Write a control register
                 drv.write(trs.addr, trs.data);

--- a/sim/hw/tb_user.sv
+++ b/sim/hw/tb_user.sv
@@ -378,6 +378,9 @@ module tb_user;
         
         #(RST_PERIOD) aresetn = 1'b1;
 
+        // Wait some more because otherwise reset pipelining might swallow up some data
+        #(RST_PERIOD);
+
         env_threads();
         env_done();
 

--- a/sim/unit_test/fpga_test_case.py
+++ b/sim/unit_test/fpga_test_case.py
@@ -391,7 +391,7 @@ class FPGATestCase(unittest.TestCase):
         periodically and waiting for the output is canceled when the event is set. In this case,
         None will be returned!
         """
-        self._io_writer.ctrl_read(id, stop_event)
+        return self._io_writer.ctrl_read(id, stop_event)
 
     def set_stream_input(
         self,


### PR DESCRIPTION
## Description
Some timing stuff was broken because of busy mailbox get() and the unit-test framework never correctly returned the results of a getCSR.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results
Works for me.

