### PR TITLE
Fixed many synthesis warnings

### DIFF
--- a/hw/hdl/pkg/axi_intf.sv
+++ b/hw/hdl/pkg/axi_intf.sv
@@ -306,6 +306,7 @@ modport s (
 	output bresp, bvalid
 );
 
+`ifndef SYNTHESIS
 // Clocking blocks for simulation timing
 clocking cbm @(posedge aclk);
     default input #INPUT_TIMING output #OUTPUT_TIMING;
@@ -355,6 +356,7 @@ endclocking
 `ASSERT_STABLE(bresp, bvalid, bready);
 `ASSERT_NOT_UNDEFINED(bvalid);
 `ASSERT_NOT_UNDEFINED(bready);
+`endif
 
 endinterface
 
@@ -404,12 +406,14 @@ modport s (
     output tready
 );
 
+`ifndef SYNTHESIS
 // Assertions
 `ASSERT_SIGNAL_STABLE(tdata);
 `ASSERT_SIGNAL_STABLE(tkeep);
 `ASSERT_SIGNAL_STABLE(tlast);
 `ASSERT_NOT_UNDEFINED(tvalid);
 `ASSERT_NOT_UNDEFINED(tready);
+`endif
 
 endinterface
 
@@ -464,6 +468,7 @@ modport s (
     output tready
 );
 
+`ifndef SYNTHESIS
 // Clocking blocks for simulation timing
 clocking cbm @(posedge aclk);
     default input #INPUT_TIMING output #OUTPUT_TIMING;
@@ -484,6 +489,7 @@ endclocking
 `ASSERT_SIGNAL_STABLE(tlast);
 `ASSERT_NOT_UNDEFINED(tvalid);
 `ASSERT_NOT_UNDEFINED(tready);
+`endif
 
 endinterface
 

--- a/hw/hdl/pkg/lynx_intf.sv
+++ b/hw/hdl/pkg/lynx_intf.sv
@@ -70,6 +70,7 @@ modport m (
 	output data
 );
 
+`ifndef SYNTHESIS
 // Clocking blocks for simulation timing
 clocking cbm @(posedge aclk);
     default input #INPUT_TIMING output #OUTPUT_TIMING;
@@ -87,6 +88,7 @@ endclocking
 `ASSERT_STABLE(data, valid, ready);
 `ASSERT_NOT_UNDEFINED(valid);
 `ASSERT_NOT_UNDEFINED(ready);
+`endif
 
 endinterface
 

--- a/hw/templates/lynx_pkg_tmplt.txt
+++ b/hw/templates/lynx_pkg_tmplt.txt
@@ -139,252 +139,252 @@ package lynxTypes;
     // Static
     // ========================---------------------------------------------
 
-    parameter string BUILD_DIR = "{{ cnfg.build_dir }}";
+    localparam string BUILD_DIR = "{{ cnfg.build_dir }}";
 
     // AXI
-    parameter integer AXIL_DATA_BITS = 64;
-    parameter integer AVX_DATA_BITS = 256;
-    parameter integer AXI_DATA_BITS = 512;
-    parameter integer AXI_ADDR_BITS = 64;
-    parameter integer AXI_NET_BITS = 512;
-    parameter integer AXI_DDR_BITS = 512;
-    parameter integer AXI_TLB_BITS = 128;
-    parameter integer AXI_ID_BITS = 6;
-    parameter integer AXI_BPSS_BAR_BITS = 28;
+    localparam integer AXIL_DATA_BITS = 64;
+    localparam integer AVX_DATA_BITS = 256;
+    localparam integer AXI_DATA_BITS = 512;
+    localparam integer AXI_ADDR_BITS = 64;
+    localparam integer AXI_NET_BITS = 512;
+    localparam integer AXI_DDR_BITS = 512;
+    localparam integer AXI_TLB_BITS = 128;
+    localparam integer AXI_ID_BITS = 6;
+    localparam integer AXI_BPSS_BAR_BITS = 28;
 
     // TLB ram
-    parameter integer TLB_S_ORDER = {{ cnfg.tlbs_s }};
-    parameter integer PG_S_BITS = {{ cnfg.tlbs_bits }};
-    parameter integer N_S_ASSOC = {{ cnfg.tlbs_a }};
+    localparam integer TLB_S_ORDER = {{ cnfg.tlbs_s }};
+    localparam integer PG_S_BITS = {{ cnfg.tlbs_bits }};
+    localparam integer N_S_ASSOC = {{ cnfg.tlbs_a }};
 
-    parameter integer TLB_L_ORDER = {{ cnfg.tlbl_s }};
-    parameter integer PG_L_BITS = {{ cnfg.tlbl_bits }};
-    parameter integer N_L_ASSOC = {{ cnfg.tlbl_a }};
+    localparam integer TLB_L_ORDER = {{ cnfg.tlbl_s }};
+    localparam integer PG_L_BITS = {{ cnfg.tlbl_bits }};
+    localparam integer N_L_ASSOC = {{ cnfg.tlbl_a }};
 
-    parameter integer TLB_DATA_BITS = 104;
-    parameter integer N_TLB_ACTV = {{ cnfg.n_tlb_actv }};
+    localparam integer TLB_DATA_BITS = 104;
+    localparam integer N_TLB_ACTV = {{ cnfg.n_tlb_actv }};
 
-    parameter integer TLB_TMR_REF_CLR = 100000;
-    parameter integer CACHE_MAX_SIZE = 32;
+    localparam integer TLB_TMR_REF_CLR = 100000;
+    localparam integer CACHE_MAX_SIZE = 32;
 
     // IRQ
-    parameter integer IRQ_OFFL = 0;
-    parameter integer IRQ_SYNC = 1;
-    parameter integer IRQ_INVLDT = 2;
-    parameter integer IRQ_PFAULT = 3;
-    parameter integer IRQ_NOTIFY = 4;
-    parameter integer IRQ_RCNFG = 5;
+    localparam integer IRQ_OFFL = 0;
+    localparam integer IRQ_SYNC = 1;
+    localparam integer IRQ_INVLDT = 2;
+    localparam integer IRQ_PFAULT = 3;
+    localparam integer IRQ_NOTIFY = 4;
+    localparam integer IRQ_RCNFG = 5;
 
     // Data
-    parameter integer ADDR_BITS = 64;
-    parameter integer PADDR_BITS = 44;
-    parameter integer VADDR_BITS = {{ cnfg.vaddr_bits }};
-    parameter integer LEN_BITS = 28;
-    parameter integer DEST_BITS = {{ cnfg.data_dest_bits }};
-    parameter integer PID_BITS = 6;
-    parameter integer HPID_BITS = 32;
-    parameter integer USER_BITS = 4;
-    parameter integer NOTIFY_BITS = 32;
-    parameter integer BEAT_LOG_BITS = $clog2(AXI_DATA_BITS/8);
-    parameter integer BLEN_BITS = LEN_BITS - BEAT_LOG_BITS;
-    parameter integer OFFS_BITS = 6;
-    parameter integer OPCODE_BITS = 5;
-    parameter integer STRM_BITS = 2;
+    localparam integer ADDR_BITS = 64;
+    localparam integer PADDR_BITS = 44;
+    localparam integer VADDR_BITS = {{ cnfg.vaddr_bits }};
+    localparam integer LEN_BITS = 28;
+    localparam integer DEST_BITS = {{ cnfg.data_dest_bits }};
+    localparam integer PID_BITS = 6;
+    localparam integer HPID_BITS = 32;
+    localparam integer USER_BITS = 4;
+    localparam integer NOTIFY_BITS = 32;
+    localparam integer BEAT_LOG_BITS = $clog2(AXI_DATA_BITS/8);
+    localparam integer BLEN_BITS = LEN_BITS - BEAT_LOG_BITS;
+    localparam integer OFFS_BITS = 6;
+    localparam integer OPCODE_BITS = 5;
+    localparam integer STRM_BITS = 2;
 
-    parameter integer LOCAL_READ = 1;
-    parameter integer LOCAL_WRITE = 2;
-    parameter integer LOCAL_TRANSFER = 3;
-    parameter integer LOCAL_OFFLOAD = 4;
-    parameter integer LOCAL_SYNC = 5;
+    localparam integer LOCAL_READ = 1;
+    localparam integer LOCAL_WRITE = 2;
+    localparam integer LOCAL_TRANSFER = 3;
+    localparam integer LOCAL_OFFLOAD = 4;
+    localparam integer LOCAL_SYNC = 5;
 
-    parameter integer STRM_CARD = 0;
-    parameter integer STRM_HOST = 1;
-    parameter integer STRM_RDMA = 2;
-    parameter integer STRM_TCP = 3;
+    localparam integer STRM_CARD = 0;
+    localparam integer STRM_HOST = 1;
+    localparam integer STRM_RDMA = 2;
+    localparam integer STRM_TCP = 3;
 
     // Queue depth
-    parameter integer QUEUE_DEPTH = 8;
+    localparam integer QUEUE_DEPTH = 8;
 
     // Slices
-    parameter integer N_REG_STAT_S0 = {{ cnfg.nr_st_s0 }}; // 2
-    parameter integer N_REG_STAT_S1 = {{ cnfg.nr_st_s1 }}; // 2
-    parameter integer N_REG_SHELL_S0 = {{ cnfg.nr_sh_s0 }}; // 2
-    parameter integer N_REG_SHELL_S1 = {{ cnfg.nr_sh_s1 }}; // 2
-    parameter integer N_REG_DYN_HOST_S0 = {{ cnfg.nr_dh_s0 }}; // 4
-    parameter integer N_REG_DYN_HOST_S1 = {{ cnfg.nr_dh_s1 }}; // 3
-    parameter integer N_REG_DYN_CARD_S0 = {{ cnfg.nr_dc_s0 }}; // 4
-    parameter integer N_REG_DYN_CARD_S1 = {{ cnfg.nr_dc_s1 }}; // 3
-    parameter integer N_REG_DYN_NET_S0 = {{ cnfg.nr_dn_s0 }}; // 4
-    parameter integer N_REG_DYN_NET_S1 = {{ cnfg.nr_dn_s1 }}; // 3
-    parameter integer N_REG_NET_S0 = {{ cnfg.nr_n_s0 }}; // 4
-    parameter integer N_REG_NET_S1 = {{ cnfg.nr_n_s1 }}; // 3
-    parameter integer N_REG_NET_S2 = {{ cnfg.nr_n_s2 }}; // 4
-    parameter integer N_REG_STA_DCPL = {{ cnfg.nr_sd }}; // 3
-    parameter integer N_REG_DYN_DCPL = {{ cnfg.nr_dd }}; // 3
-    parameter integer N_REG_PR = {{ cnfg.nr_pr }}; // 4
-    parameter integer NET_STATS_DELAY = {{ cnfg.nr_nst }}; // 4
-    parameter integer XDMA_STATS_DELAY = {{ cnfg.nr_xst }}; // 4
+    localparam integer N_REG_STAT_S0 = {{ cnfg.nr_st_s0 }}; // 2
+    localparam integer N_REG_STAT_S1 = {{ cnfg.nr_st_s1 }}; // 2
+    localparam integer N_REG_SHELL_S0 = {{ cnfg.nr_sh_s0 }}; // 2
+    localparam integer N_REG_SHELL_S1 = {{ cnfg.nr_sh_s1 }}; // 2
+    localparam integer N_REG_DYN_HOST_S0 = {{ cnfg.nr_dh_s0 }}; // 4
+    localparam integer N_REG_DYN_HOST_S1 = {{ cnfg.nr_dh_s1 }}; // 3
+    localparam integer N_REG_DYN_CARD_S0 = {{ cnfg.nr_dc_s0 }}; // 4
+    localparam integer N_REG_DYN_CARD_S1 = {{ cnfg.nr_dc_s1 }}; // 3
+    localparam integer N_REG_DYN_NET_S0 = {{ cnfg.nr_dn_s0 }}; // 4
+    localparam integer N_REG_DYN_NET_S1 = {{ cnfg.nr_dn_s1 }}; // 3
+    localparam integer N_REG_NET_S0 = {{ cnfg.nr_n_s0 }}; // 4
+    localparam integer N_REG_NET_S1 = {{ cnfg.nr_n_s1 }}; // 3
+    localparam integer N_REG_NET_S2 = {{ cnfg.nr_n_s2 }}; // 4
+    localparam integer N_REG_STA_DCPL = {{ cnfg.nr_sd }}; // 3
+    localparam integer N_REG_DYN_DCPL = {{ cnfg.nr_dd }}; // 3
+    localparam integer N_REG_PR = {{ cnfg.nr_pr }}; // 4
+    localparam integer NET_STATS_DELAY = {{ cnfg.nr_nst }}; // 4
+    localparam integer XDMA_STATS_DELAY = {{ cnfg.nr_xst }}; // 4
 
     // LEGACY Enzian support
-    parameter integer N_REG_ECI_S0 = {{ cnfg.nr_e_s0 }}; // 3
-    parameter integer N_REG_ECI_S1 = {{ cnfg.nr_e_s1 }}; // 2
+    localparam integer N_REG_ECI_S0 = {{ cnfg.nr_e_s0 }}; // 3
+    localparam integer N_REG_ECI_S1 = {{ cnfg.nr_e_s1 }}; // 2
 
     // Network
-    parameter integer ARP_LUP_REQ_BITS = 32;
-    parameter integer ARP_LUP_RSP_BITS = 56;
-    parameter integer IP_ADDR_BITS = 32;
-    parameter integer MAC_ADDR_BITS = 48;
-    parameter integer DEF_MAC_ADDRESS = 48'hE59D02350A00; // LSB first, 00:0A:35:02:9D:E5
-    parameter integer DEF_IP_ADDRESS = 32'hD1D4010B; // LSB first, 0B:01:D4:D1
-    parameter integer NET_STRM_DOWN_THRS = 256;
+    localparam integer ARP_LUP_REQ_BITS = 32;
+    localparam integer ARP_LUP_RSP_BITS = 56;
+    localparam integer IP_ADDR_BITS = 32;
+    localparam integer MAC_ADDR_BITS = 48;
+    localparam integer DEF_MAC_ADDRESS = 48'hE59D02350A00; // LSB first, 00:0A:35:02:9D:E5
+    localparam integer DEF_IP_ADDRESS = 32'hD1D4010B; // LSB first, 0B:01:D4:D1
+    localparam integer NET_STRM_DOWN_THRS = 256;
 
     // Network buffers
-    parameter integer MEM_CMD_BITS = 96;
-    parameter integer MEM_STS_BITS = 8;
+    localparam integer MEM_CMD_BITS = 96;
+    localparam integer MEM_STS_BITS = 8;
 
     // Network RDMA
-    parameter integer APP_READ = 0;
-    parameter integer APP_WRITE = 1;
-    parameter integer APP_SEND = 2;
-    parameter integer APP_IMMED = 3;
+    localparam integer APP_READ = 0;
+    localparam integer APP_WRITE = 1;
+    localparam integer APP_SEND = 2;
+    localparam integer APP_IMMED = 3;
 
-    parameter integer RC_SEND_FIRST = 5'h0;
-    parameter integer RC_SEND_MIDDLE = 5'h1;
-    parameter integer RC_SEND_LAST = 5'h2;
-    parameter integer RC_SEND_ONLY = 5'h4;
-    parameter integer RC_RDMA_WRITE_FIRST = 5'h6;
-    parameter integer RC_RDMA_WRITE_MIDDLE = 5'h7;
-    parameter integer RC_RDMA_WRITE_LAST = 5'h8;
-    parameter integer RC_RDMA_WRITE_LAST_WITH_IMD = 5'h9;
-    parameter integer RC_RDMA_WRITE_ONLY = 5'hA;
-    parameter integer RC_RDMA_WRITE_ONLY_WIT_IMD = 5'hB;
-    parameter integer RC_RDMA_READ_REQUEST = 5'hC;
-    parameter integer RC_RDMA_READ_RESP_FIRST = 5'hD;
-    parameter integer RC_RDMA_READ_RESP_MIDDLE = 5'hE;
-    parameter integer RC_RDMA_READ_RESP_LAST = 5'hF;
-    parameter integer RC_RDMA_READ_RESP_ONLY = 5'h10;
-    parameter integer RC_ACK = 5'h11;
+    localparam integer RC_SEND_FIRST = 5'h0;
+    localparam integer RC_SEND_MIDDLE = 5'h1;
+    localparam integer RC_SEND_LAST = 5'h2;
+    localparam integer RC_SEND_ONLY = 5'h4;
+    localparam integer RC_RDMA_WRITE_FIRST = 5'h6;
+    localparam integer RC_RDMA_WRITE_MIDDLE = 5'h7;
+    localparam integer RC_RDMA_WRITE_LAST = 5'h8;
+    localparam integer RC_RDMA_WRITE_LAST_WITH_IMD = 5'h9;
+    localparam integer RC_RDMA_WRITE_ONLY = 5'hA;
+    localparam integer RC_RDMA_WRITE_ONLY_WIT_IMD = 5'hB;
+    localparam integer RC_RDMA_READ_REQUEST = 5'hC;
+    localparam integer RC_RDMA_READ_RESP_FIRST = 5'hD;
+    localparam integer RC_RDMA_READ_RESP_MIDDLE = 5'hE;
+    localparam integer RC_RDMA_READ_RESP_LAST = 5'hF;
+    localparam integer RC_RDMA_READ_RESP_ONLY = 5'h10;
+    localparam integer RC_ACK = 5'h11;
 
-    parameter integer RDMA_ACK_BITS = 64;
-    parameter integer RDMA_ACK_QPN_BITS = 10;
-    parameter integer RDMA_ACK_SYNDROME_BITS = 8;
-    parameter integer RDMA_ACK_PSN_BITS = 24;
-    parameter integer RDMA_ACK_MSN_BITS = 24;
-    parameter integer RDMA_BASE_REQ_BITS = 144;
-    parameter integer RDMA_VADDR_BITS = 64;
-    parameter integer RDMA_LEN_BITS = 32;
-    parameter integer RDMA_REQ_BITS = 248;
-    parameter integer RDMA_OPCODE_BITS = 5;
-    parameter integer RDMA_QPN_BITS = 16;
-    parameter integer RDMA_IMM_BITS = 32;
-    parameter integer RDMA_QP_INTF_BITS = 168;
-    parameter integer RDMA_QP_CONN_BITS = 184;
-    parameter integer RDMA_LVADDR_OFFS = 0;
-    parameter integer RDMA_RVADDR_OFFS = RDMA_VADDR_BITS;
-    parameter integer RDMA_LEN_OFFS = 2*RDMA_VADDR_BITS;
-    parameter integer RDMA_PARAMS_OFFS = 2*RDMA_VADDR_BITS + RDMA_LEN_BITS;
-    parameter integer RDMA_MSN_BITS = 24;
-    parameter integer RDMA_SNDRM_BITS = 8;
-    parameter integer RDMA_N_RD_OUTSTANDING = 8;
-    parameter integer RDMA_N_WR_OUTSTANDING = 16;
-    parameter integer RDMA_MAX_SINGLE_READ = 32 * 1024;
-    parameter integer RDMA_MODE_PARSE = 0;
-    parameter integer RDMA_MODE_RAW = 1;
-    parameter integer RDMA_WR_NET_THRS = 256; // beats
-    parameter integer RDMA_MEM_SHIFT = 27;
+    localparam integer RDMA_ACK_BITS = 64;
+    localparam integer RDMA_ACK_QPN_BITS = 10;
+    localparam integer RDMA_ACK_SYNDROME_BITS = 8;
+    localparam integer RDMA_ACK_PSN_BITS = 24;
+    localparam integer RDMA_ACK_MSN_BITS = 24;
+    localparam integer RDMA_BASE_REQ_BITS = 144;
+    localparam integer RDMA_VADDR_BITS = 64;
+    localparam integer RDMA_LEN_BITS = 32;
+    localparam integer RDMA_REQ_BITS = 248;
+    localparam integer RDMA_OPCODE_BITS = 5;
+    localparam integer RDMA_QPN_BITS = 16;
+    localparam integer RDMA_IMM_BITS = 32;
+    localparam integer RDMA_QP_INTF_BITS = 168;
+    localparam integer RDMA_QP_CONN_BITS = 184;
+    localparam integer RDMA_LVADDR_OFFS = 0;
+    localparam integer RDMA_RVADDR_OFFS = RDMA_VADDR_BITS;
+    localparam integer RDMA_LEN_OFFS = 2*RDMA_VADDR_BITS;
+    localparam integer RDMA_PARAMS_OFFS = 2*RDMA_VADDR_BITS + RDMA_LEN_BITS;
+    localparam integer RDMA_MSN_BITS = 24;
+    localparam integer RDMA_SNDRM_BITS = 8;
+    localparam integer RDMA_N_RD_OUTSTANDING = 8;
+    localparam integer RDMA_N_WR_OUTSTANDING = 16;
+    localparam integer RDMA_MAX_SINGLE_READ = 32 * 1024;
+    localparam integer RDMA_MODE_PARSE = 0;
+    localparam integer RDMA_MODE_RAW = 1;
+    localparam integer RDMA_WR_NET_THRS = 256; // beats
+    localparam integer RDMA_MEM_SHIFT = 27;
 
     // Network TCP/IP
-    parameter integer N_TCP_CHANNELS = 2;
-    parameter integer TCP_PORT_OFFS = 49152;
-    parameter integer TCP_PORT_ORDER = 10;
-    parameter integer TCP_RSESSION_BITS = DEST_BITS + PID_BITS + DEST_BITS;
-    parameter integer TCP_PORT_TABLE_DATA_BITS = 16;
-    parameter integer TCP_PORT_REQ_BITS = 16;
-    parameter integer TCP_PORT_RSP_BITS = 8;
-    parameter integer TCP_OPEN_CONN_REQ_BITS = 48;
-    parameter integer TCP_OPEN_CONN_RSP_BITS = 72;
-    parameter integer TCP_CLOSE_CONN_REQ_BITS = 16;
-    parameter integer TCP_NOTIFY_BITS = 88;
-    parameter integer TCP_RD_PKG_REQ_BITS = 32;
-    parameter integer TCP_RX_META_BITS = 16;
-    parameter integer TCP_TX_META_BITS = 32;
-    parameter integer TCP_TX_STAT_BITS = 64;
+    localparam integer N_TCP_CHANNELS = 2;
+    localparam integer TCP_PORT_OFFS = 49152;
+    localparam integer TCP_PORT_ORDER = 10;
+    localparam integer TCP_RSESSION_BITS = DEST_BITS + PID_BITS + DEST_BITS;
+    localparam integer TCP_PORT_TABLE_DATA_BITS = 16;
+    localparam integer TCP_PORT_REQ_BITS = 16;
+    localparam integer TCP_PORT_RSP_BITS = 8;
+    localparam integer TCP_OPEN_CONN_REQ_BITS = 48;
+    localparam integer TCP_OPEN_CONN_RSP_BITS = 72;
+    localparam integer TCP_CLOSE_CONN_REQ_BITS = 16;
+    localparam integer TCP_NOTIFY_BITS = 88;
+    localparam integer TCP_RD_PKG_REQ_BITS = 32;
+    localparam integer TCP_RX_META_BITS = 16;
+    localparam integer TCP_TX_META_BITS = 32;
+    localparam integer TCP_TX_STAT_BITS = 64;
 
-    parameter integer TCP_IP_ADDRESS_BITS = 32;
-    parameter integer TCP_IP_PORT_BITS = 16;
-    parameter integer TCP_SESSION_BITS = 16;
-    parameter integer TCP_SUCCESS_BITS = 8;
-    parameter integer TCP_LEN_BITS = 16;
-    parameter integer TCP_REM_SPACE_BITS = 30;
-    parameter integer TCP_ERROR_BITS = 2;
-    parameter integer TCP_MEM_SHIFT = 0;
-    parameter integer TCP_SID_BITS = 10;
-    parameter integer TCP_OPCODE = 0;
+    localparam integer TCP_IP_ADDRESS_BITS = 32;
+    localparam integer TCP_IP_PORT_BITS = 16;
+    localparam integer TCP_SESSION_BITS = 16;
+    localparam integer TCP_SUCCESS_BITS = 8;
+    localparam integer TCP_LEN_BITS = 16;
+    localparam integer TCP_REM_SPACE_BITS = 30;
+    localparam integer TCP_ERROR_BITS = 2;
+    localparam integer TCP_MEM_SHIFT = 0;
+    localparam integer TCP_SID_BITS = 10;
+    localparam integer TCP_OPCODE = 0;
 
     // ECI
-    parameter integer N_LANES = 12;
-    parameter integer N_LANES_GRPS = 3;
-    parameter integer ECI_DATA_BITS = 1024;
-    parameter integer ECI_ADDR_BITS = 40;
-    parameter integer ECI_ID_BITS = 5;
-    parameter integer ECI_WORD_BITS = 64;
+    localparam integer N_LANES = 12;
+    localparam integer N_LANES_GRPS = 3;
+    localparam integer ECI_DATA_BITS = 1024;
+    localparam integer ECI_ADDR_BITS = 40;
+    localparam integer ECI_ID_BITS = 5;
+    localparam integer ECI_WORD_BITS = 64;
 
     // ========================---------------------------------------------
     // Dynamic
     // ========================---------------------------------------------
 
     // SIM
-    parameter CLK_PERIOD = {{ cnfg.sim_clock_period }};
-    parameter RST_PERIOD = 20 * CLK_PERIOD;
-    parameter AST_PERIOD = 40 * CLK_PERIOD;
-    parameter INPUT_TIMING  = 1step;
-    parameter OUTPUT_TIMING = 1step;
+    localparam CLK_PERIOD = {{ cnfg.sim_clock_period }};
+    localparam RST_PERIOD = 20 * CLK_PERIOD;
+    localparam AST_PERIOD = 40 * CLK_PERIOD;
+    localparam INPUT_TIMING  = 1step;
+    localparam OUTPUT_TIMING = 1step;
 
     // Flow
-    parameter string  FDEV = "{{ cnfg.fdev }}";
+    localparam string  FDEV = "{{ cnfg.fdev }}";
     
-    parameter integer N_XCHAN = {{ cnfg.n_xchan }};
-    parameter integer N_XCHAN_BITS = clog2s(N_XCHAN);
-    parameter integer N_SCHAN = {{ cnfg.n_schan }};
-    parameter integer N_SCHAN_BITS = clog2s({{ cnfg.n_schan }});
-    parameter integer N_CHAN = {{ cnfg.n_chan }};
-    parameter integer N_CHAN_BITS = clog2s({{ cnfg.n_chan }});
+    localparam integer N_XCHAN = {{ cnfg.n_xchan }};
+    localparam integer N_XCHAN_BITS = clog2s(N_XCHAN);
+    localparam integer N_SCHAN = {{ cnfg.n_schan }};
+    localparam integer N_SCHAN_BITS = clog2s({{ cnfg.n_schan }});
+    localparam integer N_CHAN = {{ cnfg.n_chan }};
+    localparam integer N_CHAN_BITS = clog2s({{ cnfg.n_chan }});
     
-    parameter integer STAT_PROBE = {{ cnfg.stat_probe }};
-    parameter integer SHELL_PROBE = {{ cnfg.shell_probe }};
+    localparam integer STAT_PROBE = {{ cnfg.stat_probe }};
+    localparam integer SHELL_PROBE = {{ cnfg.shell_probe }};
     
-    parameter integer N_REGIONS = {{ cnfg.n_reg }};
-    parameter integer N_REGIONS_BITS = clog2s({{ cnfg.n_reg }});
+    localparam integer N_REGIONS = {{ cnfg.n_reg }};
+    localparam integer N_REGIONS_BITS = clog2s({{ cnfg.n_reg }});
 
-    parameter integer N_OUTSTANDING = {{ cnfg.n_outs }};
-    parameter integer N_OUTSTANDING_REGION = {{ 4 * cnfg.n_outs }};
+    localparam integer N_OUTSTANDING = {{ cnfg.n_outs }};
+    localparam integer N_OUTSTANDING_REGION = {{ 4 * cnfg.n_outs }};
 
-    parameter integer PMTU_BYTES = {{ cnfg.pmtu }};
+    localparam integer PMTU_BYTES = {{ cnfg.pmtu }};
     
-    parameter integer DDR_CHAN_SIZE = {{ cnfg.ddr_size }};
-    parameter integer HBM_CHAN_SIZE = {{ cnfg.hbm_size }};
+    localparam integer DDR_CHAN_SIZE = {{ cnfg.ddr_size }};
+    localparam integer HBM_CHAN_SIZE = {{ cnfg.hbm_size }};
     
-    parameter integer N_DDR_CHAN = {{ cnfg.n_ddr_chan }};
-    parameter integer N_DDR_CHAN_BITS = clog2s({{ cnfg.n_ddr_chan }});
-    parameter integer N_MEM_CHAN = {{ cnfg.n_mem_chan }};
-    parameter integer N_MEM_CHAN_BITS = clog2s({{ cnfg.n_mem_chan }});
-    parameter integer DDR_FRAG_SIZE = {{ cnfg.ddr_frag }};
-    parameter integer PR_FLOW = {{ cnfg.en_pr }};
-    parameter integer RECONFIG_EOS_TIME = {{ cnfg.eos_time }};
+    localparam integer N_DDR_CHAN = {{ cnfg.n_ddr_chan }};
+    localparam integer N_DDR_CHAN_BITS = clog2s({{ cnfg.n_ddr_chan }});
+    localparam integer N_MEM_CHAN = {{ cnfg.n_mem_chan }};
+    localparam integer N_MEM_CHAN_BITS = clog2s({{ cnfg.n_mem_chan }});
+    localparam integer DDR_FRAG_SIZE = {{ cnfg.ddr_frag }};
+    localparam integer PR_FLOW = {{ cnfg.en_pr }};
+    localparam integer RECONFIG_EOS_TIME = {{ cnfg.eos_time }};
 
-    parameter integer AVX_FLOW = {{ cnfg.en_avx }};
-    parameter integer BPSS_FLOW = 1;
-    parameter integer WB_FLOW = {{ cnfg.en_wb }};
-    parameter integer STRM_FLOW = {{ cnfg.en_strm }};
-    parameter integer MEM_FLOW = {{ cnfg.en_mem }};
-    parameter integer RDMA_FLOW = {{ cnfg.en_rdma }};
-    parameter integer TCP_FLOW = {{ cnfg.en_tcp }};
-    parameter integer N_WBS = {{ cnfg.n_wbs }};
-    parameter integer QSFP = {{ cnfg.qsfp }};
+    localparam integer AVX_FLOW = {{ cnfg.en_avx }};
+    localparam integer BPSS_FLOW = 1;
+    localparam integer WB_FLOW = {{ cnfg.en_wb }};
+    localparam integer STRM_FLOW = {{ cnfg.en_strm }};
+    localparam integer MEM_FLOW = {{ cnfg.en_mem }};
+    localparam integer RDMA_FLOW = {{ cnfg.en_rdma }};
+    localparam integer TCP_FLOW = {{ cnfg.en_tcp }};
+    localparam integer N_WBS = {{ cnfg.n_wbs }};
+    localparam integer QSFP = {{ cnfg.qsfp }};
 
-    parameter integer N_CARD_AXI = {{ cnfg.n_card_axi }};
-    parameter integer N_STRM_AXI = {{ cnfg.n_strm_axi }};
-    parameter integer N_RDMA_AXI = {{ cnfg.n_rdma_axi }};
+    localparam integer N_CARD_AXI = {{ cnfg.n_card_axi }};
+    localparam integer N_STRM_AXI = {{ cnfg.n_strm_axi }};
+    localparam integer N_RDMA_AXI = {{ cnfg.n_rdma_axi }};
 
     // ========================---------------------------------------------
     // Structs

--- a/hw/templates/user_wrapper_tmplt.txt
+++ b/hw/templates/user_wrapper_tmplt.txt
@@ -219,8 +219,8 @@ module design_user_wrapper_{{ c_reg }} (
     //
 
     // AXIL control
-    AXI4L axi_ctrl_user();
-    AXI4L axi_ctrl_user_int();
+    AXI4L axi_ctrl_user(.*);
+    AXI4L axi_ctrl_user_int(.*);
 
     assign axi_ctrl_user.araddr                 = axi_ctrl_araddr;
     assign axi_ctrl_user.arprot                 = axi_ctrl_arprot;
@@ -243,26 +243,26 @@ module design_user_wrapper_{{ c_reg }} (
     assign axi_ctrl_wready                      = axi_ctrl_user.wready;
 
     // Notify
-    metaIntf #(.STYPE(irq_not_t)) notify ();
-    metaIntf #(.STYPE(irq_not_t)) notify_int ();
+    metaIntf #(.STYPE(irq_not_t)) notify (.*);
+    metaIntf #(.STYPE(irq_not_t)) notify_int (.*);
 
     assign notify_valid                         = notify.valid;
     assign notify_data                          = notify.data;
     assign notify.ready                         = notify_ready;
 
     // Host descriptors
-    metaIntf #(.STYPE(dreq_t)) host_sq ();
-    metaIntf #(.STYPE(dreq_t)) host_sq_int ();
+    metaIntf #(.STYPE(dreq_t)) host_sq (.*);
+    metaIntf #(.STYPE(dreq_t)) host_sq_int (.*);
     
     assign host_sq.valid                        = host_sq_valid;
     assign host_sq_ready                        = host_sq.ready;
     assign host_sq.data                         = host_sq_data;
 
     // Bypass descriptors
-    metaIntf #(.STYPE(req_t)) bpss_rd_req ();
-    metaIntf #(.STYPE(req_t)) bpss_wr_req ();
-    metaIntf #(.STYPE(req_t)) bpss_rd_req_int ();
-    metaIntf #(.STYPE(req_t)) bpss_wr_req_int ();
+    metaIntf #(.STYPE(req_t)) bpss_rd_req (.*);
+    metaIntf #(.STYPE(req_t)) bpss_wr_req (.*);
+    metaIntf #(.STYPE(req_t)) bpss_rd_req_int (.*);
+    metaIntf #(.STYPE(req_t)) bpss_wr_req_int (.*);
     
     assign bpss_rd_sq_valid                     = bpss_rd_req.valid;
     assign bpss_rd_req.ready                    = bpss_rd_sq_ready; 
@@ -272,10 +272,10 @@ module design_user_wrapper_{{ c_reg }} (
     assign bpss_wr_req.ready                    = bpss_wr_sq_ready; 
     assign bpss_wr_sq_data                      = bpss_wr_req.data; 
 
-    metaIntf #(.STYPE(ack_t)) bpss_rd_cq ();
-    metaIntf #(.STYPE(ack_t)) bpss_wr_cq ();
-    metaIntf #(.STYPE(ack_t)) bpss_rd_cq_int ();
-    metaIntf #(.STYPE(ack_t)) bpss_wr_cq_int ();
+    metaIntf #(.STYPE(ack_t)) bpss_rd_cq (.*);
+    metaIntf #(.STYPE(ack_t)) bpss_wr_cq (.*);
+    metaIntf #(.STYPE(ack_t)) bpss_rd_cq_int (.*);
+    metaIntf #(.STYPE(ack_t)) bpss_wr_cq_int (.*);
 
     assign bpss_rd_cq.valid                     = bpss_rd_cq_valid;
     assign bpss_rd_cq.data                      = bpss_rd_cq_data;
@@ -287,29 +287,29 @@ module design_user_wrapper_{{ c_reg }} (
 
 {% if cnfg.en_rdma %}
     // RDMA descriptors
-    metaIntf #(.STYPE(dreq_t)) rdma_sq ();
-    metaIntf #(.STYPE(dreq_t)) rdma_sq_int ();
+    metaIntf #(.STYPE(dreq_t)) rdma_sq (.*);
+    metaIntf #(.STYPE(dreq_t)) rdma_sq_int (.*);
 
     assign rdma_sq_valid                        = rdma_sq.valid;
     assign rdma_sq.ready                        = rdma_sq_ready;
     assign rdma_sq_data                         = rdma_sq.data;
 
-    metaIntf #(.STYPE(ack_t)) rdma_cq ();
-    metaIntf #(.STYPE(ack_t)) rdma_cq_int ();
+    metaIntf #(.STYPE(ack_t)) rdma_cq (.*);
+    metaIntf #(.STYPE(ack_t)) rdma_cq_int (.*);
 
     assign rdma_cq.valid                        = rdma_cq_valid;
     assign rdma_cq_ready                        = rdma_cq.ready;
     assign rdma_cq.data                         = rdma_cq_data;
 
-    metaIntf #(.STYPE(req_t)) rdma_rq_wr ();
-    metaIntf #(.STYPE(req_t)) rdma_rq_wr_int ();
+    metaIntf #(.STYPE(req_t)) rdma_rq_wr (.*);
+    metaIntf #(.STYPE(req_t)) rdma_rq_wr_int (.*);
 
     assign rdma_rq_wr.valid                     = rdma_rq_wr_valid;
     assign rdma_rq_wr_ready                     = rdma_rq_wr.ready;
     assign rdma_rq_wr.data                      = rdma_rq_wr_data;
 
-    metaIntf #(.STYPE(req_t)) rdma_rq_rd ();
-    metaIntf #(.STYPE(req_t)) rdma_rq_rd_int ();
+    metaIntf #(.STYPE(req_t)) rdma_rq_rd (.*);
+    metaIntf #(.STYPE(req_t)) rdma_rq_rd_int (.*);
 
     assign rdma_rq_rd.valid                     = rdma_rq_rd_valid;
     assign rdma_rq_rd_ready                     = rdma_rq_rd.ready;
@@ -318,15 +318,15 @@ module design_user_wrapper_{{ c_reg }} (
 {% endif %}
 {% if cnfg.en_tcp %}
     // TCP descriptors
-    metaIntf #(.STYPE(req_t)) tcp_sq ();
-    metaIntf #(.STYPE(req_t)) tcp_sq_int ();
+    metaIntf #(.STYPE(req_t)) tcp_sq (.*);
+    metaIntf #(.STYPE(req_t)) tcp_sq_int (.*);
 
     assign tcp_sq_valid                         = tcp_sq.valid;
     assign tcp_sq.ready                         = tcp_sq_ready;
     assign tcp_sq_data                          = tcp_sq.data;
 
-    metaIntf #(.STYPE(req_t)) tcp_rq ();
-    metaIntf #(.STYPE(req_t)) tcp_rq_int ();
+    metaIntf #(.STYPE(req_t)) tcp_rq (.*);
+    metaIntf #(.STYPE(req_t)) tcp_rq_int (.*);
 
     assign tcp_rq.valid                         = tcp_rq_valid;
     assign tcp_rq_ready                         = tcp_rq.ready;
@@ -334,8 +334,8 @@ module design_user_wrapper_{{ c_reg }} (
 
 {% endif %}
 {% if cnfg.en_strm %}
-    AXI4S axis_host_sink ();
-    AXI4S axis_host_sink_int ();
+    AXI4S axis_host_sink (.*);
+    AXI4S axis_host_sink_int (.*);
 
     assign axis_host_sink.tvalid                = axis_host_sink_tvalid;
     assign axis_host_sink.tdata                 = axis_host_sink_tdata;
@@ -343,8 +343,8 @@ module design_user_wrapper_{{ c_reg }} (
     assign axis_host_sink.tlast                 = axis_host_sink_tlast;
     assign axis_host_sink_tready                = axis_host_sink.tready;
 
-    AXI4S axis_host_src ();
-    AXI4S axis_host_src_int ();
+    AXI4S axis_host_src (.*);
+    AXI4S axis_host_src_int (.*);
 
     assign axis_host_src_tvalid                 = axis_host_src.tvalid;
     assign axis_host_src_tdata                  = axis_host_src.tdata;
@@ -354,8 +354,8 @@ module design_user_wrapper_{{ c_reg }} (
 {% endif %}
 
 {% if cnfg.en_mem %}
-    AXI4S axis_card_sink [N_CARD_AXI] ();
-    AXI4S axis_card_sink_int [N_CARD_AXI] ();
+    AXI4S axis_card_sink [N_CARD_AXI] (.*);
+    AXI4S axis_card_sink_int [N_CARD_AXI] (.*);
 
 {% for i in range(0, cnfg.n_card_axi) %}
     assign axis_card_sink[{{i}}].tdata          = axis_card_{{i}}_sink_tdata;
@@ -365,8 +365,8 @@ module design_user_wrapper_{{ c_reg }} (
     assign axis_card_{{i}}_sink_tready          = axis_card_sink[{{i}}].tready;
 {% endfor %}
 
-    AXI4S axis_card_src [N_CARD_AXI] ();
-    AXI4S axis_card_src_int [N_CARD_AXI] ();
+    AXI4S axis_card_src [N_CARD_AXI] (.*);
+    AXI4S axis_card_src_int [N_CARD_AXI] (.*);
 
 {% for i in range(0, cnfg.n_card_axi) %}
     assign axis_card_{{i}}_src_tdata            = axis_card_src[{{i}}].tdata;
@@ -378,8 +378,8 @@ module design_user_wrapper_{{ c_reg }} (
 {% endfor %}
 {% endif %}
 {% if cnfg.en_rdma %}
-    AXI4S axis_rdma_sink ();
-    AXI4S axis_rdma_sink_int ();
+    AXI4S axis_rdma_sink (.*);
+    AXI4S axis_rdma_sink_int (.*);
 
     assign axis_rdma_sink.tvalid                = axis_rdma_sink_tvalid;
     assign axis_rdma_sink.tdata                 = axis_rdma_sink_tdata;
@@ -387,8 +387,8 @@ module design_user_wrapper_{{ c_reg }} (
     assign axis_rdma_sink.tlast                 = axis_rdma_sink_tlast;
     assign axis_rdma_sink_tready                = axis_rdma_sink.tready;
 
-    AXI4S axis_rdma_src_req ();
-    AXI4S axis_rdma_src_req_int ();
+    AXI4S axis_rdma_src_req (.*);
+    AXI4S axis_rdma_src_req_int (.*);
 
     assign axis_rdma_src_req_tvalid                 = axis_rdma_src_req.tvalid;
     assign axis_rdma_src_req_tdata                  = axis_rdma_src_req.tdata;
@@ -396,8 +396,8 @@ module design_user_wrapper_{{ c_reg }} (
     assign axis_rdma_src_req_tlast                  = axis_rdma_src_req.tlast;
     assign axis_rdma_src_req.tready                 = axis_rdma_src_req_tready;
 
-    AXI4S axis_rdma_src_rsp ();
-    AXI4S axis_rdma_src_rsp_int ();
+    AXI4S axis_rdma_src_rsp (.*);
+    AXI4S axis_rdma_src_rsp_int (.*);
 
     assign axis_rdma_src_rsp_tvalid                 = axis_rdma_src_rsp.tvalid;
     assign axis_rdma_src_rsp_tdata                  = axis_rdma_src_rsp.tdata;
@@ -407,8 +407,8 @@ module design_user_wrapper_{{ c_reg }} (
 
 {% endif %}
 {% if cnfg.en_tcp %}
-    AXI4S axis_tcp_sink ();
-    AXI4S axis_tcp_sink_int ();
+    AXI4S axis_tcp_sink (.*);
+    AXI4S axis_tcp_sink_int (.*);
 
     assign axis_tcp_sink.tvalid                 = axis_tcp_sink_tvalid;
     assign axis_tcp_sink.tdata                  = axis_tcp_sink_tdata;
@@ -416,8 +416,8 @@ module design_user_wrapper_{{ c_reg }} (
     assign axis_tcp_sink.tlast                  = axis_tcp_sink_tlast;
     assign axis_tcp_sink_tready                 = axis_tcp_sink.tready;
 
-    AXI4S axis_tcp_src ();
-    AXI4S axis_tcp_src_int ();
+    AXI4S axis_tcp_src (.*);
+    AXI4S axis_tcp_src_int (.*);
 
     assign axis_tcp_src_tvalid                  = axis_tcp_src.tvalid;
     assign axis_tcp_src_tdata                   = axis_tcp_src.tdata;
@@ -428,9 +428,9 @@ module design_user_wrapper_{{ c_reg }} (
 {% endif %}
 
 {% if ( cnfg.en_sniffer and ( cnfg.sniffer_vfpga_id == c_reg ) ) %}
-    AXI4S #(.AXI4S_DATA_BITS(AXI_NET_BITS)) rx_sniffer ();
-    AXI4S #(.AXI4S_DATA_BITS(AXI_NET_BITS)) tx_sniffer ();
-    metaIntf #(.STYPE(logic[64-1:0])) filter_config ();
+    AXI4S #(.AXI4S_DATA_BITS(AXI_NET_BITS)) rx_sniffer (.*);
+    AXI4S #(.AXI4S_DATA_BITS(AXI_NET_BITS)) tx_sniffer (.*);
+    metaIntf #(.STYPE(logic[64-1:0])) filter_config (.*);
 
     assign rx_sniffer.tdata          = rx_sniffer_tdata;
     assign rx_sniffer.tkeep          = rx_sniffer_tkeep;
@@ -577,25 +577,25 @@ module design_user_wrapper_{{ c_reg }} (
     // SQ
     //
 
-    metaIntf #(.STYPE(req_t)) user_sq_rd_int ();
-    metaIntf #(.STYPE(req_t)) user_sq_wr_int ();
+    metaIntf #(.STYPE(req_t)) user_sq_rd_int (.*);
+    metaIntf #(.STYPE(req_t)) user_sq_wr_int (.*);
 
-    metaIntf #(.STYPE(req_t)) host_local_sq_rd ();
-    metaIntf #(.STYPE(req_t)) host_local_sq_wr ();
-    metaIntf #(.STYPE(req_t)) user_local_sq_rd ();
-    metaIntf #(.STYPE(req_t)) user_local_sq_wr ();
+    metaIntf #(.STYPE(req_t)) host_local_sq_rd (.*);
+    metaIntf #(.STYPE(req_t)) host_local_sq_wr (.*);
+    metaIntf #(.STYPE(req_t)) user_local_sq_rd (.*);
+    metaIntf #(.STYPE(req_t)) user_local_sq_wr (.*);
 
-    metaIntf #(.STYPE(req_t)) local_sq_rd ();
-    metaIntf #(.STYPE(req_t)) local_sq_wr ();
+    metaIntf #(.STYPE(req_t)) local_sq_rd (.*);
+    metaIntf #(.STYPE(req_t)) local_sq_wr (.*);
 
 {% if cnfg.en_net %}
-    metaIntf #(.STYPE(dreq_t)) host_remote_sq_rd ();
-    metaIntf #(.STYPE(dreq_t)) host_remote_sq_wr ();
-    metaIntf #(.STYPE(dreq_t)) user_remote_sq_rd ();
-    metaIntf #(.STYPE(dreq_t)) user_remote_sq_wr ();
+    metaIntf #(.STYPE(dreq_t)) host_remote_sq_rd (.*);
+    metaIntf #(.STYPE(dreq_t)) host_remote_sq_wr (.*);
+    metaIntf #(.STYPE(dreq_t)) user_remote_sq_rd (.*);
+    metaIntf #(.STYPE(dreq_t)) user_remote_sq_wr (.*);
 
-    metaIntf #(.STYPE(dreq_t)) remote_sq_rd ();
-    metaIntf #(.STYPE(dreq_t)) remote_sq_wr ();
+    metaIntf #(.STYPE(dreq_t)) remote_sq_rd (.*);
+    metaIntf #(.STYPE(dreq_t)) remote_sq_wr (.*);
 
 {% endif %}
 
@@ -666,20 +666,20 @@ module design_user_wrapper_{{ c_reg }} (
     //
     // Local credits
     // 
-    metaIntf #(.STYPE(req_t)) local_sq_rd_host ();
-    metaIntf #(.STYPE(req_t)) local_sq_rd_card ();
-    metaIntf #(.STYPE(req_t)) local_sq_wr_host ();
-    metaIntf #(.STYPE(req_t)) local_sq_wr_card ();
+    metaIntf #(.STYPE(req_t)) local_sq_rd_host (.*);
+    metaIntf #(.STYPE(req_t)) local_sq_rd_card (.*);
+    metaIntf #(.STYPE(req_t)) local_sq_wr_host (.*);
+    metaIntf #(.STYPE(req_t)) local_sq_wr_card (.*);
 
-    metaIntf #(.STYPE(req_t)) local_cred_rd_host ();
-    metaIntf #(.STYPE(req_t)) local_cred_rd_card ();
-    metaIntf #(.STYPE(req_t)) local_cred_wr_host ();
-    metaIntf #(.STYPE(req_t)) local_cred_wr_card ();
+    metaIntf #(.STYPE(req_t)) local_cred_rd_host (.*);
+    metaIntf #(.STYPE(req_t)) local_cred_rd_card (.*);
+    metaIntf #(.STYPE(req_t)) local_cred_wr_host (.*);
+    metaIntf #(.STYPE(req_t)) local_cred_wr_card (.*);
 
-    AXI4SR axis_host_send_int [N_STRM_AXI] ();
-    AXI4SR axis_host_recv_int [N_STRM_AXI] ();
-    AXI4SR axis_card_send_int [N_CARD_AXI] ();
-    AXI4SR axis_card_recv_int [N_CARD_AXI] (); 
+    AXI4SR axis_host_send_int [N_STRM_AXI] (.*);
+    AXI4SR axis_host_recv_int [N_STRM_AXI] (.*);
+    AXI4SR axis_card_send_int [N_CARD_AXI] (.*);
+    AXI4SR axis_card_recv_int [N_CARD_AXI] (.*); 
     
 {% if cnfg.en_strm and cnfg.en_mem %}
     req_mux_stream_1_2 inst_stream_mux_rd (
@@ -823,29 +823,29 @@ module design_user_wrapper_{{ c_reg }} (
     // 
 
 {% if cnfg.en_net %}
-    metaIntf #(.STYPE(req_t)) user_rq_wr_int ();
+    metaIntf #(.STYPE(req_t)) user_rq_wr_int (.*);
 
 {% if cnfg.en_rdma %}
-    metaIntf #(.STYPE(req_t)) user_rq_rd_int ();
+    metaIntf #(.STYPE(req_t)) user_rq_rd_int (.*);
 
-    metaIntf #(.STYPE(dreq_t)) remote_sq_wr_rdma ();
-    metaIntf #(.STYPE(dreq_t)) remote_cred_rd_rdma ();
-    metaIntf #(.STYPE(dreq_t)) remote_cred_wr_rdma ();
+    metaIntf #(.STYPE(dreq_t)) remote_sq_wr_rdma (.*);
+    metaIntf #(.STYPE(dreq_t)) remote_cred_rd_rdma (.*);
+    metaIntf #(.STYPE(dreq_t)) remote_cred_wr_rdma (.*);
 
-    metaIntf #(.STYPE(req_t)) rdma_rq_wr_cred_int ();
+    metaIntf #(.STYPE(req_t)) rdma_rq_wr_cred_int (.*);
 
-    AXI4SR axis_rdma_recv_int [N_RDMA_AXI] ();
-    AXI4SR axis_rdma_resp_int [N_RDMA_AXI] ();
-    AXI4SR axis_rdma_send_req_int [N_RDMA_AXI] ();
-    AXI4SR axis_rdma_send_rsp_int [N_RDMA_AXI] ();
+    AXI4SR axis_rdma_recv_int [N_RDMA_AXI] (.*);
+    AXI4SR axis_rdma_resp_int [N_RDMA_AXI] (.*);
+    AXI4SR axis_rdma_send_req_int [N_RDMA_AXI] (.*);
+    AXI4SR axis_rdma_send_rsp_int [N_RDMA_AXI] (.*);
 
 {% endif %}
 {% if cnfg.en_tcp %}
-    metaIntf #(.STYPE(req_t)) remote_sq_wr_tcp ();
-    metaIntf #(.STYPE(req_t)) remote_sq_cmd_tcp ();
-    metaIntf #(.STYPE(req_t)) remote_cred_wr_tcp ();
+    metaIntf #(.STYPE(req_t)) remote_sq_wr_tcp (.*);
+    metaIntf #(.STYPE(req_t)) remote_sq_cmd_tcp (.*);
+    metaIntf #(.STYPE(req_t)) remote_cred_wr_tcp (.*);
 
-    metaIntf #(.STYPE(req_t)) tcp_rq_wr_int ();
+    metaIntf #(.STYPE(req_t)) tcp_rq_wr_int (.*);
     
 {% endif %}
 {% if cnfg.en_tcp and cnfg.en_rdma %}
@@ -1009,8 +1009,8 @@ module design_user_wrapper_{{ c_reg }} (
     // CQ
     // 
 
-    metaIntf #(.STYPE(ack_t)) user_cq_rd_int ();
-    metaIntf #(.STYPE(ack_t)) user_cq_wr_int ();
+    metaIntf #(.STYPE(ack_t)) user_cq_rd_int (.*);
+    metaIntf #(.STYPE(ack_t)) user_cq_wr_int (.*);
 
 {% if cnfg.en_rdma %}
     cq_arb inst_cq_arbiter (


### PR DESCRIPTION
This gets rid of hundreds of synthesis warnings for parameter usage in a package, clocking blocks and assertions, and undefined interface signals

## Description
> :memo: Please include a summary of the change

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results
Synthesized fine.
