### PR TITLE
Fix for tlast being high in the middle of transfers and for transfers that do not have last flagged in the request

### DIFF
--- a/hw/hdl/mmu/axis_last_rewriter.sv
+++ b/hw/hdl/mmu/axis_last_rewriter.sv
@@ -2,7 +2,7 @@
  * This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
  *
  * MIT Licence
- * Copyright (c) 2021-2025, Systems Group, ETH Zurich
+ * Copyright (c) 2025, Systems Group, ETH Zurich
  * All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -35,9 +35,6 @@ import lynxTypes::*;
  * the original request.
  */
 module axis_last_rewriter (
-    input logic aclk,
-    input logic aresetn,
-
     metaIntf.s s_fwd_last,
 
     AXI4S.s s_axis,

--- a/hw/templates/dynamic_top_tmplt.txt
+++ b/hw/templates/dynamic_top_tmplt.txt
@@ -340,7 +340,7 @@ module design_dynamic_top #(
 
     for(genvar i = 0; i < N_REGIONS; i++) begin
         for(genvar j = 0; j < N_CARD_AXI; j++) begin
-            axis_last_rewriter inst_card_rewrite_rd (.aclk(aclk), .aresetn(aresetn), .s_fwd_last(rd_fwd_last_card[i * N_CARD_AXI + j]), .s_axis(axis_card_in_s1[i * N_CARD_AXI + j]), .m_axis(axis_card_in_s2[i * N_CARD_AXI + j]));
+            axis_last_rewriter inst_card_rewrite_rd (.s_fwd_last(rd_fwd_last_card[i * N_CARD_AXI + j]), .s_axis(axis_card_in_s1[i * N_CARD_AXI + j]), .m_axis(axis_card_in_s2[i * N_CARD_AXI + j]));
             `AXIS_ASSIGN(axis_card_out_s2[i * N_CARD_AXI + j], axis_card_out_s1[i * N_CARD_AXI + j])
         end
     end

--- a/sim/hw/c_axil.svh
+++ b/sim/hw/c_axil.svh
@@ -67,9 +67,10 @@ class c_axil;
 
     // Write
     task write (
-        input logic [AXI_ADDR_BITS-1:0] addr,
-        input logic [AXIL_DATA_BITS-1:0] data,
-        input logic is_dummy = 0
+        input  logic [AXI_ADDR_BITS-1:0] addr,
+        input  logic [AXIL_DATA_BITS-1:0] data,
+        output logic [1:0] resp,
+        input  logic is_dummy = 0
     );      
         // Request
         axi.cbm.awaddr  <= addr;
@@ -94,12 +95,14 @@ class c_axil;
         axi.cbm.bready <= 1'b0;
 
         `VERBOSE(("write() completed. Addr: %x, data: %0d", addr, data))
+        resp = axi.cbm.bresp;
     endtask
 
     // Read
     task read (
         input  logic [AXI_ADDR_BITS-1:0]  addr,
-		output logic [AXIL_DATA_BITS-1:0] data
+		output logic [AXIL_DATA_BITS-1:0] data,
+        output logic [1:0]                resp
     );
         // Request
         axi.cbm.araddr  <= addr;
@@ -115,6 +118,7 @@ class c_axil;
 
         `VERBOSE(("read() completed. Addr: %x, data: %0d", addr, axi.cbm.rdata))
 		data = axi.cbm.rdata;
+        resp = axi.cbm.rresp;
     endtask
 
 endclass

--- a/sim/hw/ctrl_simulation.svh
+++ b/sim/hw/ctrl_simulation.svh
@@ -28,7 +28,8 @@
 `include "scoreboard.svh"
 
 /* 
-* This class reads input from a text file and either generates a write to the axi_ctrl stream, or it reads data from the axi_ctrl stream until certain bits match before execution continues
+* This class reads input from a text file and either generates a write to the axi_ctrl stream, or it 
+* reads data from the axi_ctrl stream until certain bits match before execution continues.
 */
 
 class ctrl_simulation;
@@ -50,7 +51,9 @@ class ctrl_simulation;
 
     task run();
         trs_ctrl trs;
+        logic [1:0]                resp;
         logic [AXIL_DATA_BITS-1:0] read_data;
+        logic [AXIL_DATA_BITS-1:0] read_burst_data;
 
         forever begin
             // We need this as non-blocking with @(...), otherwise timing might be off if we do a 
@@ -62,20 +65,33 @@ class ctrl_simulation;
             end
 
             if (trs.is_write) begin // Write a control register
-                drv.write(trs.addr, trs.data);
+                drv.write(trs.addr, trs.data, resp);
+                `ASSERT(resp == 2'b00, ("Write status has to be 2'b00 (OK) but is 2'b%b.", resp))
                 `DEBUG(("Write register: %x, data: %0d", trs.addr, trs.data))
 
-            `ifdef EN_RANDOMIZATION // Dummy writes which happen in real hardware because of the AVX512 writing of registers
-                for (int i = 0; i < 7; i++) begin drv.write(trs.addr + i, $urandom(), 1); end
-            `endif
+                `ifdef EN_RANDOMIZATION // Write burst which happens in real hardware
+                    for (int i = 1; i < 8 - ((trs.addr / 8) % 8); i++) begin 
+                        drv.write(trs.addr + 8 * i, $urandom(), resp, 1);
+                        `ASSERT(resp == 2'b00, ("Write status has to be 2'b00 (OK) but is 2'b%b.", resp))
+                    end
+                `endif
             end else begin // Read from a control register
-                drv.read(trs.addr, read_data);
+                drv.read(trs.addr, read_data, resp);
+                `ASSERT(resp == 2'b00, ("Read status has to be 2'b00 (OK) but is 2'b%b.", resp))
+
                 if (trs.do_polling) begin
                     while (read_data != trs.data) begin
-                        drv.read(trs.addr, read_data);
+                        drv.read(trs.addr, read_data, resp);
                     end
                     -> polling_done;
                 end
+
+                `ifdef EN_RANDOMIZATION // Read burst which happens in real hardware
+                    for (int i = 1; i < 8 - ((trs.addr / 8) % 8); i++) begin 
+                        drv.read(trs.addr + 8 * i, read_burst_data, resp);
+                        `ASSERT(resp == 2'b00, ("Read status has to be 2'b00 (OK) but is 2'b%b.", resp))
+                    end
+                `endif
                 scb.writeCTRL(read_data);
                 `DEBUG(("Read register: %x, data: %0d", trs.addr, read_data))
             end


### PR DESCRIPTION
## Description
I added a last signal rewriter module which gets the last signals of requests that go from the TLB to the CDMA through a FIFO. It then overwrites the last signal of the incoming data streams from memory based on this forwarded request last signal.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results
I tested this with the 01_hello_world and 07_perf_fpga examples. Also put an ILA on the new module which works as intended.
