### PR TITLE
Fix host request arbiter to ensure fair sharing

### DIFF
--- a/hw/hdl/mmu/mmu_arbiter.sv
+++ b/hw/hdl/mmu/mmu_arbiter.sv
@@ -96,15 +96,17 @@ assign done_src = m_req.rsp.done;
 // RR
 // --------------------------------------------------------------------------------
 always_ff @(posedge aclk) begin
-	if(aresetn == 1'b0) begin
-		rr_reg <= 0;
-	end else begin
-        if(valid_src & ready_src) begin 
-            rr_reg <= rr_reg + 1;
-            if(rr_reg >= N_REGIONS-1)
+    if (aresetn == 1'b0) begin
+        rr_reg <= 0;
+    end else begin
+        if (valid_src && ready_src) begin
+            if (vfid == N_REGIONS-1) begin
                 rr_reg <= 0;
+            end else begin
+                rr_reg <= vfid + 1;
+            end
         end
-	end
+    end
 end
 
 // DP


### PR DESCRIPTION
## Description
The current implementation of the mmu_arbiter is flawed in some (corner) cases. If the bitstream is synthesised with N_REGIONS vFPGAs but less than N_REGIONS are issuing requests, certain vFPGAs will be given preference. For example, for a design with 4 vFPGA where only 2 vFPGAs issue requests (e.g., 0, 1 are issuing requests, and 2, 3 are idle), vFPGA 0 will be granted more requests than vFPGA 1. The reason for this is the scanning, loop around round-robin implementation: the RR position starts at zero, and every time a request is issued, increments by 1. Then, at each step the algorithm starts at the current position of RR and checks all the next vFPGAs until it finds one that issues a request. If it doesn't find one, it loops back to vFPGA 0, 1 etc. More concretely, for the example above:

- Initially, RR position = 0.
- Then vFPGA 0 issues request and since the RR position is equal to zero, it immediately grans the access. Position increments by 1.
- Now, vFPGA 1 issues a request, and since RR position equals to one, it is immediately executed. Position increments by 1.
- After the last step, the position is 2. Since neither vFPGA 2 nor 3 are issuing requests, the "next" one that the algorithm finds is vFPGA 0. And again, position increments to 3, for which, again, vFPGA 0 will be given access.
- So in this case, with 4 vFPGAs in the design and 2 vFPGA issuing requests, vFPGA 0 was given 3/4 accesses while vFPGA 1 was given 1/4 accesses (when they were truly concurrent).

The fix for this is rather simple - the RR position does not increment by one for every request granted; instead, it is set to the last granted vFPGA ID + 1. When all are issuing requests, this is equivalent to the 'increment by 1' implementation. But when less are issuing requests, it ensures fairness.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results
The "unfair" behaviour can be observed in Example 3 by changing the BATCHED_TRANSFERS variable to 1 and running with 2 vFPGA (-n 2). It will show that vFPGA 0 achieves higher throughout (~9 GBps) than vFPGA 1 (~6 GBps). If synthesised with this fix, they achieve similar performance. 

Fix tested on u55c, u250 and v80, working as expected.

### Checklist
- [x] I have commented my code and made corresponding changes to the documentation.
- [x] I have added tests/results that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings or errors & all tests successfully pass.
