### PR TITLE
fix cmake install files

### DIFF
--- a/sim/sw/CMakeLists.txt
+++ b/sim/sw/CMakeLists.txt
@@ -92,8 +92,8 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/coyote/"
 
 # Export package configuration
 install(EXPORT CoyoteSimulationTargets
-    FILE CoyoteSimulationTargets.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/coyotesim
+    FILE CoyoteSimulationConfig.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CoyoteSimulation
 )
 
 # Generate CMake package configuration files

--- a/sw/CMakeLists.txt
+++ b/sw/CMakeLists.txt
@@ -177,8 +177,8 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/coyote/"
 
 # Export package configuration
 install(EXPORT CoyoteTargets
-    FILE CoyoteTargets.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/coyote
+    FILE CoyoteConfig.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Coyote
 )
 
 # Generate CMake package configuration files


### PR DESCRIPTION
The way the CMake files for Coyote are installed will not resolve with `find_package` as expected. This is an issue I introduced in #185 . With this minimal change the filename matches what CMake expects and thus `find_package` works fine. 

```
CMake Error at CMakeLists.txt:214 (find_package):
  By not providing "FindCoyote.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Coyote", but
  CMake did not find one.

  Could not find a package configuration file provided by "Coyote" with any
  of the following names:

    CoyoteConfig.cmake
    coyote-config.cmake

  Add the installation prefix of "Coyote" to CMAKE_PREFIX_PATH or set
  "Coyote_DIR" to a directory containing one of the above files.  If "Coyote"
  provides a separate development package or SDK, be sure it has been
  installed.
```

Previously, installing Coyote would place files in, for example:
```
-- Installing: /pub/scratch/ltagliavini/dest/lib/cmake/CoyoteTargets.cmake
-- Installing: /pub/scratch/ltagliavini/dest/lib/cmake/CoyoteTargets-debug.cmake
```
Whereas, now they're installed with the proper name:
```
-- Installing: /pub/scratch/ltagliavini/dest/lib/cmake/coyote/CoyoteConfig.cmake
-- Installing: /pub/scratch/ltagliavini/dest/lib/cmake/coyote/CoyoteConfig-debug.cmake
```