### PR TITLE
Updates to GPU memory allocation to align with P2P paper

### DIFF
--- a/sw/CMakeLists.txt
+++ b/sw/CMakeLists.txt
@@ -152,7 +152,7 @@ if(EN_GPU)
     )
 
     # Add GPU libraries
-    target_link_libraries(Coyote PUBLIC hip::device numa pthread drm drm_amdgpu rt dl hsa-runtime64 hsakmt)
+    target_link_libraries(Coyote PUBLIC hip::device numa pthread drm drm_amdgpu rt dl hsa-runtime64 hsakmt rocm_smi64)
 endif()
 
 ##############################

--- a/sw/include/coyote/cGpu.hpp
+++ b/sw/include/coyote/cGpu.hpp
@@ -34,6 +34,7 @@
 #include <stdexcept>
 
 #include <hsa.h>
+#include <hip/hip_runtime.h>
 #include <hsa/hsa_ext_amd.h>
 
 namespace coyote {

--- a/sw/src/cThread.cpp
+++ b/sw/src/cThread.cpp
@@ -486,9 +486,8 @@ void* cThread::getMem(CoyoteAlloc&& alloc) {
                 #endif 
 
                 // Allocate the GPU memory
-                err = hsa_memory_allocate(*info_params.region, alloc.size, (void **) &(mem)); 
-                if (err != HSA_STATUS_SUCCESS) {
-                    std::cerr << "ERROR: cThread::getMem() - Failed to allocate GPU memory!" << std::endl;;
+                if (hipMalloc((void **) &mem, alloc.size)) {
+                    std::cerr << "ERROR: cThread::getMem() - hipMalloc failed to allocate GPU memory!" << std::endl;;
                     return nullptr;
                 }
                 


### PR DESCRIPTION
## Description
Updates in GPU memory allocation to use HIP instead of HSA (higher-level function) & adds a library for measuring GPU power/util.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] A new research paper code implementation
- [ ] Other

## Tests & Results
> P2P example works as expected.

### Checklist
- [x] I have commented my code and made corresponding changes to the documentation.
- [x] I have added tests/results that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings or errors & all tests successfully pass.
