### PR TITLE
Fixed unwanted interrupt reordering

### DIFF
--- a/driver/src/coyote_setup.c
+++ b/driver/src/coyote_setup.c
@@ -365,13 +365,13 @@ int setup_vfpga_devices(struct bus_driver_data *data) {
         mutex_init(&data->vfpga_dev[i].pid_lock);
 
         // Initialize workqueues
-        data->vfpga_dev[i].wqueue_pfault = alloc_workqueue(COYOTE_DRIVER_NAME, WQ_UNBOUND | WQ_MEM_RECLAIM, 0);
+        data->vfpga_dev[i].wqueue_pfault = alloc_workqueue(COYOTE_DRIVER_NAME, WQ_UNBOUND | WQ_MEM_RECLAIM, 1);
         if(!data->vfpga_dev[i].wqueue_pfault) {
             pr_err("page fault work queue not initialized\n");
             goto err_pfault_wqueue;
         }
 
-        data->vfpga_dev[i].wqueue_notify = alloc_workqueue(COYOTE_DRIVER_NAME, WQ_UNBOUND | WQ_MEM_RECLAIM, 0);
+        data->vfpga_dev[i].wqueue_notify = alloc_workqueue(COYOTE_DRIVER_NAME, WQ_UNBOUND | WQ_MEM_RECLAIM, 1);
         if(!data->vfpga_dev[i].wqueue_notify) {
             pr_err("notify work queue not initialized\n");
             goto err_notify_wqueue;


### PR DESCRIPTION


## Description
We saw interrupts arriving in software in the wrong order. This was caused by multiple worker threads on driver internal interrupt queues. We set the number of workers to 1 now.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other
