### PR TITLE
Correctly set tlast in RDMA re-transmission multiplexer

### DIFF
--- a/hw/hdl/network/rdma/rdma_mux_retrans.sv
+++ b/hw/hdl/network/rdma/rdma_mux_retrans.sv
@@ -358,7 +358,7 @@ assign axis_net.tlast = actv_C ? (rd_C ? s_axis_user_rsp.tlast : s_axis_user_req
 // Data-loop? Not exactly what this is for. Seems to loop data back from the top-level module to the top-level module 
 assign axis_ddr_wr.tdata = s_axis_user_req.tdata;
 assign axis_ddr_wr.tkeep = s_axis_user_req.tkeep;
-assign axis_ddr_wr.tlast = (cnt_ddr_wr == 1);
+assign axis_ddr_wr.tlast = (cnt_C == 0);
 
 //
 // DEBUG


### PR DESCRIPTION
## Description
> Fixes the incorrectly set tlast signal in RDMA retrans MUX by considering the current command, not incoming command. This bug could lead to erroneous transmissions (as reported in PR #191) as well as critical failures in ACCL.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results
Confirmed by running Example 9 dozens of times, with 100 runs and 128 throughput repetitions. Close to 200M packets exchanged with no drops.

### Checklist
- [x] I have commented my code and made corresponding changes to the documentation.
- [x] I have added tests/results that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings or errors & all tests successfully pass.
