### PR TITLE
Fix include path for SW docs after SW refractor

### DIFF
--- a/docs/Doxyfile-sw
+++ b/docs/Doxyfile-sw
@@ -1,8 +1,8 @@
 PROJECT_NAME = "docs-sw"
 
-INPUT = ../sw/include/
+INPUT = ../sw/include/coyote/
 OUTPUT_DIRECTORY = docs-sw/
-STRIP_FROM_PATH = ../sw/include/
+STRIP_FROM_PATH = ../sw/include/coyote/
 EXCLUDE_PATTERNS = */cDefs.hpp
 
 GENERATE_XML 		= YES


### PR DESCRIPTION
## Description
The PR which refactored Coyote's SW to be included as a library, inadvertently broke the auto-generated SW docs, which relied on a path. 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

### Checklist
- [x] I have commented my code and made corresponding changes to the documentation.
- [x] I have added tests/results that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings or errors & all tests successfully pass.
