### PR TITLE
Fix for unit test read_register unpacking the returned value as a signed integer

### DIFF
--- a/sim/unit_test/io_writer.py
+++ b/sim/unit_test/io_writer.py
@@ -244,7 +244,7 @@ class SimulationIOWriter:
         self, output_file: BinaryIO, stop_event: threading.Event, logger: logging.Logger
     ):
         # The output should be a single, 8 byte value
-        format = f"{self.byte_order}q"
+        format = f"{self.byte_order}Q"
         size = struct.calcsize(format)
         data = self._read_exactly_n_bytes_from_output_file(
             output_file, size, stop_event


### PR DESCRIPTION
## Description
As in title.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results
Tested with one project relying on this.
