### PR TITLE
Changed allocation size type from uint32_t to uint64_t

### DIFF
--- a/examples/11_packet_sniffer/sw/src/main.cpp
+++ b/examples/11_packet_sniffer/sw/src/main.cpp
@@ -156,7 +156,7 @@ int main(int argc, char *argv[]) {
 
     // vfpga handler and mem alloc
     coyote::cThread cthread(target_vfid, getpid(), cs_device);
-    void *hMem = cthread.getMem({coyote::CoyoteAllocType::HPF, (uint32_t)coyote::HUGE_PAGE_SIZE * host_mem_pages});
+    void *hMem = cthread.getMem({coyote::CoyoteAllocType::HPF, coyote::HUGE_PAGE_SIZE * host_mem_pages});
     memset(hMem, 0, coyote::HUGE_PAGE_SIZE * host_mem_pages);
     // offload memory to card for buffering captured packets
     coyote::syncSg hmem_sg = { .addr = (void *)((uintptr_t)hMem), .len = coyote::HUGE_PAGE_SIZE * host_mem_pages };

--- a/sim/sw/src/cThread.cpp
+++ b/sim/sw/src/cThread.cpp
@@ -204,7 +204,7 @@ void cThread::munmapFpga() {
     // Do nothing because protected function
 }
 
-void cThread::userMap(void *vaddr, uint32_t len, int32_t mem_block) {
+void cThread::userMap(void *vaddr, uint64_t len, int32_t mem_block) {
     if (mem_block != -1) {
         WARNING("Non-default values for mem_block " << mem_block << "are currently ignored");
     }
@@ -507,7 +507,7 @@ void cThread::connSync(bool client) {
     ASSERT("Networking not implemented in simulation target")
 }
 
-void* cThread::initRDMA(uint32_t buffer_size, uint16_t port, const char* server_address) {
+void* cThread::initRDMA(uint64_t buffer_size, uint16_t port, const char* server_address) {
     ASSERT("Networking not implemented in simulation target")
     return nullptr;
 }

--- a/sw/include/coyote/cDefs.hpp
+++ b/sw/include/coyote/cDefs.hpp
@@ -325,7 +325,7 @@ struct ibvQ {
     void *vaddr;
 
     /// Buffer size
-    uint32_t size;
+    uint64_t size;
 
     /**
      * @brief Global ID for identifying a network interface in RDMA networks (InfiniBand or RoCE).
@@ -357,7 +357,7 @@ struct ibvQ {
     /// Debug print
     void print(const char *name) {
         printf(
-            "%s: QPN 0x%06x, PSN 0x%06x, VADDR %016lx, SIZE %08x, IP 0x%08x\n",
+            "%s: QPN 0x%06x, PSN 0x%06x, VADDR %016lx, SIZE %016lx, IP 0x%08x\n",
             name, qpn, psn, (uint64_t)vaddr, size, ip_addr
         );
     }

--- a/sw/include/coyote/cOps.hpp
+++ b/sw/include/coyote/cOps.hpp
@@ -122,7 +122,7 @@ struct CoyoteAlloc {
 	CoyoteAllocType alloc = { CoyoteAllocType::REG };
 
 	/// Size of the allocated memory 
-	uint32_t size = { 0 };
+	uint64_t size = { 0 };
 
     /// Is this buffer used for remote operations?
     bool remote = { false };

--- a/sw/include/coyote/cThread.hpp
+++ b/sw/include/coyote/cThread.hpp
@@ -228,7 +228,7 @@ protected:
 	 * @param mem_block What memory block to store this memory in; only applicable to Versal devices
 	 *		When -1, the driver picks the first PC with sufficient space
 	 */
-	void userMap(void *vaddr, uint32_t len, int32_t mem_block = -1);
+	void userMap(void *vaddr, uint64_t len, int32_t mem_block = -1);
 
 	/**
 	 * @brief Unmaps a buffer from the vFPGA's TLB.
@@ -363,7 +363,7 @@ protected:
 	 * @param port Port number to be used for the out-of-band connection
 	 * @param server_address Optional server address to connect to; if not provided, this cThread acts as the server
 	 */
-	void* initRDMA(uint32_t buffer_size, uint16_t port, const char* server_address = nullptr);
+	void* initRDMA(uint64_t buffer_size, uint16_t port, const char* server_address = nullptr);
 	
 	/**
 	 * @brief Opposite of initRDMA; releases the the out-of-band connection which was used to exchange QP

--- a/sw/src/cRcnfg.cpp
+++ b/sw/src/cRcnfg.cpp
@@ -133,14 +133,14 @@ bitstream_t cRcnfg::readBitstream(std::ifstream& fb) {
 	DBG2("cRcnfg: Called readBitstream to read bitstream from input stream");
 	
 	// Allocate host-side, kernel memory to hold the bitsream 
-	uint32_t len = fb.tellg();
+	uint64_t len = fb.tellg();
 	fb.seekg(0);
-	uint32_t n_pages = (len + HUGE_PAGE_SIZE - 1) / HUGE_PAGE_SIZE;
+	uint64_t n_pages = (len + HUGE_PAGE_SIZE - 1) / HUGE_PAGE_SIZE;
 	void *vaddr = getMem({CoyoteAllocType::PRM, n_pages}); 
 
 	// Read the input-stream bytewise
 	uint8_t *vaddr_8 = reinterpret_cast<uint8_t *>(vaddr); 
-	for (uint32_t i = 0; i < len; i++) {
+	for (uint64_t i = 0; i < len; i++) {
 		vaddr_8[i] = readByte(fb);
 	}
 

--- a/sw/src/cThread.cpp
+++ b/sw/src/cThread.cpp
@@ -355,7 +355,7 @@ void cThread::munmapFpga() {
 	wback = 0;
 }
 
-void cThread::userMap(void *vaddr, uint32_t len, int32_t mem_block) {
+void cThread::userMap(void *vaddr, uint64_t len, int32_t mem_block) {
     DBG1("cThread: Called userMap to map user buffer, vaddr " << vaddr << ", length " << len << ", memory block " << mem_block << " and ctid " << ctid);
 
     uint64_t tmp[MAX_USER_ARGS];
@@ -1177,7 +1177,7 @@ void cThread::connSync(bool client) {
     }
 }
 
-void* cThread::initRDMA(uint32_t buffer_size, uint16_t port, const char* server_address) {
+void* cThread::initRDMA(uint64_t buffer_size, uint16_t port, const char* server_address) {
     // Served address provided, so this node is the client
     if (server_address) {
         DBG3("cThread: initRDMA called from client side with server address " << server_address);


### PR DESCRIPTION
## Description
The allocation size in Coyote was a 32bit value which did not allow to allocate more than 4GB of memory at once. This changes the type to uint64_t. This is a breaking change to the RDMA QP exchange because the serialized metadata size changes. Both sides need to be recompiled after this fix.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results
Tested in hardware with examples 01, 07, and 09. Also tested for the simulation with examples 01 and 07.
