### PR TITLE
Fix unit of size in hugepage allocation error message

### DIFF
--- a/sw/src/cThread.cpp
+++ b/sw/src/cThread.cpp
@@ -515,7 +515,7 @@ void* cThread::getMem(CoyoteAlloc&& alloc) {
                 } else {
                     int err = errno;
                     fprintf(stderr,
-                        "cThread: Hugepage allocation failed: Shell pg_l_bits=%u (requested page size = %lu KB), "
+                        "cThread: Hugepage allocation failed: Shell pg_l_bits=%u (requested page size = %lu B), "
                         "alloc.size=%zu, errno=%d (%s)\n",
                         fcnfg.ctrl_reg.pg_l_bits,
                         1UL << fcnfg.ctrl_reg.pg_l_bits,


### PR DESCRIPTION


## Description
> :memo: Please include a summary of the change

When running the Coyote Hello World example without 2 MB hugepages enabled, this error message is printed:

```
cThread: Hugepage allocation failed: Shell pg_l_bits=21 (requested page size = 2097152 KB), alloc.size=4096, errno=12 (Cannot allocate memory)
```

The `alloc.size` variable represents bytes not "KB", which should be changed in the error message.


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results
> :memo: Please describe the tests that you ran to verify your changes. Also include any numerical results (throughput/latency etc.) relevant to the change.



### Checklist
- [ ] I have commented my code and made corresponding changes to the documentation.
- [ ] I have added tests/results that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings or errors & all tests successfully pass.
