### PR TITLE
Mask IOMMU addr space to fit TLB on FPGA

### DIFF
--- a/driver/src/platform/pci_qdma.c
+++ b/driver/src/platform/pci_qdma.c
@@ -805,7 +805,7 @@ int pci_probe(struct pci_dev *pdev, const struct pci_device_id *id) {
 
     // DMA addressing
     dbg_info("sizeof(dma_addr_t) == %ld\n", sizeof(dma_addr_t));
-    ret_val = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
+    ret_val = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(TLB_PADDR_RANGE)); // 44
     if (ret_val) {
         dev_err(&pdev->dev, "failed to set 64b DMA mask\n");
         goto err_mask;

--- a/driver/src/platform/pci_xdma.c
+++ b/driver/src/platform/pci_xdma.c
@@ -617,7 +617,7 @@ int pci_probe(struct pci_dev *pdev, const struct pci_device_id *id) {
 
     // DMA addressing
     dbg_info("sizeof(dma_addr_t) == %ld\n", sizeof(dma_addr_t));
-    ret_val = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
+    ret_val = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(TLB_PADDR_RANGE)); // 44
     if (ret_val) {
         dev_err(&pdev->dev, "failed to set 64b DMA mask\n");
         goto err_mask;

--- a/examples/01_hello_world/sw/src/main.cpp
+++ b/examples/01_hello_world/sw/src/main.cpp
@@ -26,6 +26,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <sys/mman.h>
 
 // External library for easier parsing of CLI arguments by the executable
 #include <boost/program_options.hpp>


### PR DESCRIPTION
## Description
Also fixed broken include in hello world example.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results
Tested on U55C and V80 with Oasis.