### PR TITLE
Extend Coyote for VCK5000 FPGA

### DIFF
--- a/cmake/FindCoyoteHW.cmake
+++ b/cmake/FindCoyoteHW.cmake
@@ -37,7 +37,7 @@ file(MAKE_DIRECTORY ${IPREPO_DIR})
 ############################################
 ##            USER CONFIGURATION          ##
 ############################################
-# Target FPGA device; supported Alveo U55C, Alveo U280, Alveo U250, Alveo V80
+# Target FPGA device; supported Alveo U55C, Alveo U280, Alveo U250, Alveo V80, VCK5000
 set(FDEV_NAME "0" CACHE STRING "Target FPGA device")
 
 ##
@@ -430,11 +430,40 @@ macro(validation_checks_hw)
             set(N_STRIPE_CHAN 32)
             set(MEM_OFFSET 274877906944) # 0x4000000000 ~ 256 GiB
 
-            if (BUILD_SHELL OR BUILD_APP) 
+            if (BUILD_SHELL OR BUILD_APP)
                 message(" ** V80 with BUILD_SHELL=1 or BUILD_APP=1 selected, ignoring static layer clock frequency setting (SCLK_F) and defaulting to 333 MHz")
                 set(SCLK_F 333)
             endif()
-        
+
+        # vck5000 (Versal VC1902, CPM4 PCIe Gen4x8)
+        elseif(FDEV_NAME STREQUAL "vck5000")
+            # Platform details
+            set(FPGA_ARCH "versal")
+            set(FPGA_PART xcvc1902-vsvd1760-2MP-e-S CACHE STRING "FPGA Part" FORCE)
+
+            # The VCK5000 has 4x DDR4 channels (8 GB each = 32 GB total), reached over the NoC
+            # through integrated DDR memory controllers (DDRMC). Modelled as a Versal DDR device.
+            # First milestone: 1 channel (8 GB). A single axi_noc exposes only one global
+            # MC_CHAN_REGION, so all 4 DDRMCs would collide at DDR_LOW0; scaling to 4 channels
+            # (32 GB) needs per-MC region distribution (separate MC NoCs / interleave) --- see
+            # hw/bd/versal/cr_ddr.tcl. Bump N_DDR_CHAN to 4 once that lands.
+            set(DDR_SIZE 33)       # per-channel: 8 GB = 1 << 33
+            set(N_DDR_CHAN 1)
+
+            # No HBM on the VCK5000
+            set(HCLK_F 1)
+            set(HBM_SIZE 0)
+
+            # Striping across the DDR channels
+            set(MC_SIZE ${DDR_SIZE})
+            set(N_STRIPE_CHAN ${N_DDR_CHAN})
+            set(MEM_OFFSET 0)      # DDR NoC region base (DDR_LOW0); refined against the NoC map
+
+            # No static checkpoint is shipped for the VCK5000; generate one with BUILD_STATIC=1.
+            if (BUILD_SHELL OR BUILD_APP)
+                message(" ** VCK5000 has no shipped static checkpoint; run a static build (BUILD_STATIC=1, BUILD_SHELL=0) to generate static_{synthed,routed_locked}_vck5000_gen${PCIE_GEN}.dcp first, or provide it under hw/checkpoints.")
+            endif()
+
         # Fail on unsupported device
         else()
             message(FATAL_ERROR "Target device not supported.")
@@ -449,7 +478,7 @@ macro(validation_checks_hw)
         ## ! u280 has both DDR and HBM, HBM enabled by default; if DDR is required add u280 in DDR_DEV and remove it from HBM_DEV
         ## ! v80 has both DDR and HBM, HBM is enabled by default and supported; DDR not supported yet
         ##
-        set(DDR_DEV "u250")
+        set(DDR_DEV "u250" "vck5000")
         set(HBM_DEV "u55c" "u280" "v80")
 
         list(FIND DDR_DEV ${FDEV_NAME} TMP_DEV)
@@ -464,6 +493,14 @@ macro(validation_checks_hw)
             set(AV_HBM 1)
         else()
             set(AV_HBM 0)
+        endif()
+
+        # A device with no card memory (no HBM and no DDR, e.g. the VCK5000 in Stage 1) cannot
+        # provide card memory; force host-only so the shell/dynamic card-DMA (cdma) path and the
+        # axi_mem/m_axi_ddr interfaces are not generated.
+        if(EN_MEM AND NOT AV_HBM AND NOT AV_DDR)
+            message("** No card memory on ${FDEV_NAME} (no HBM/DDR) --- forcing EN_MEM=0 (host-only).")
+            set(EN_MEM 0)
         endif()
 
         ##
@@ -485,7 +522,12 @@ macro(validation_checks_hw)
 
         # Check PCIe Gen for Versal devices
         if(FPGA_ARCH STREQUAL "versal")
-            if (NOT (PCIE_GEN EQUAL 4 OR PCIE_GEN EQUAL 5))
+            if(FDEV_NAME STREQUAL "vck5000")
+                # The VCK5000 (VC1902) uses the CPM4 block. The known-good VCK5000 CPM QDMA
+                # design links at Gen3 x16 (16 transceiver lanes); Coyote's CPM_PCIE0 is set
+                # to X16 in cr_pci.tcl, so the pcie GT port must be 16 bits.
+                set(PCIE_GT_BITS 16)
+            elseif (NOT (PCIE_GEN EQUAL 4 OR PCIE_GEN EQUAL 5))
                 message(FATAL_ERROR "Versal devices only support PCIe Gen4x16 or Gen5x8.")
             else()
                 # PCIe transceiver signal is 16 bits for Gen4x16
@@ -691,8 +733,9 @@ macro(validation_checks_hw)
             set(EN_MEM_STRIPE 1)
         endif()
 
-        # To reduce PC collisions, striping is enabled on Versal devices with 'unified' HBM implementation
-        if(FPGA_ARCH STREQUAL "versal" AND HBM_IMPL STREQUAL "unified")
+        # To reduce PC collisions, striping is enabled on Versal HBM devices with 'unified' HBM
+        # implementation (the many HBM pseudo-channels). Not applicable to Versal DDR (e.g. vck5000).
+        if(FPGA_ARCH STREQUAL "versal" AND AV_HBM AND HBM_IMPL STREQUAL "unified")
             set(EN_MEM_STRIPE 1)
         endif()
 

--- a/driver/include/coyote_defs.h
+++ b/driver/include/coyote_defs.h
@@ -185,6 +185,9 @@ extern bool en_hmm;
 #define QDMA_CXT_MASK_DEF_VAL 0xFFFFFFFF
 
 #define QDMA_CTX_BUSY_VAL_DEAULT 0x00000000
+// Max poll iterations for the QDMA indirect-context busy bit before giving up
+// (guards against a wedge if the QDMA config BAR is unreachable; see wait_until_busy_cleared)
+#define QDMA_CTX_BUSY_MAX_TRIES 100000
 #define QDMA_CTX_SEL_SHIFT 1
 #define QDMA_CTX_SEL_MASK 0x0000000F
 #define QDMA_CTX_OP_SHIFT 5
@@ -213,6 +216,88 @@ extern bool en_hmm;
 #define QDMA_GLBL_VCH_HOST_PROFILE_REG 0x2c8
 #define QDMA_GLBL_BRIDGE_HOST_PROFILE_REG 0x308
 #define QDMA_DEFAULT_HOST_PROFILE_ID 0x0
+
+/*
+ * CPM4 vs CPM5(eQDMA) QDMA register-map differences.
+ *
+ * The indirect-context registers, FMAP mechanism, host-profile and prefetch-bypass
+ * features, and completion-context layout DIFFER between the Versal CPM4 QDMA (e.g.
+ * VCK5000 / VC1902) and the Versal CPM5 eQDMA (e.g. V80). The values #defined above are
+ * the CPM5/eQDMA layout (what Coyote historically targeted). At probe we read the device
+ * type and select the correct layout into bus_driver_data.qreg. Sources: AMD
+ * dma_ip_drivers, QDMA/linux-kernel/driver/libqdma/qdma_access/{qdma_cpm4_access,
+ * eqdma_cpm5_access}.
+ *
+ * Device discriminator: GLBL2_MISC_CAP (offset 0x134, same on both), bits[31:28]:
+ *   0 = soft/UltraScale+ QDMA, 1 = Versal CPM4, 2 = Versal CPM5.
+ */
+#define QDMA_GLBL2_MISC_CAP_REG   0x134
+#define QDMA_GLBL2_DEVICE_ID_SHIFT 28
+#define QDMA_GLBL2_DEVICE_ID_MASK  0xF
+#define QDMA_DEV_ID_CPM4 1
+#define QDMA_DEV_ID_CPM5 2
+
+/* Indirect-context register layout (CPM4). CPM5 values are the #defines above. */
+#define QDMA_CPM4_CTX_CMD_REG        0x824
+#define QDMA_CPM4_CTX_DATA_REG_START 0x804
+#define QDMA_CPM4_CTX_MASK_REG_START 0x814
+#define QDMA_CPM4_CTX_N_DATA_REGS    4
+#define QDMA_CPM5_CTX_CMD_REG        0x844
+#define QDMA_CPM5_CTX_DATA_REG_START 0x804
+#define QDMA_CPM5_CTX_MASK_REG_START 0x824
+#define QDMA_CPM5_CTX_N_DATA_REGS    8
+
+/* CPM4 C2H credit ring. On CPM4, C2H simple bypass still consumes RING credits per packet:
+ * the 0x1408/0x140c tag arming grants a single prefetch credit; ongoing credits come from a
+ * SW-posted host descriptor ring + PIDX doorbell (verified: with no ring, exactly ONE packet
+ * gets a DESC_RSP then the engine backpressures s_axis_c2h). The ring DESCRIPTOR CONTENT is
+ * never used (fabric supplies the real descriptor+address on byp_in_st_sim; byp_out is
+ * discarded), so rings stay zeroed. Offsets per AMD dma_ip_drivers qdma_cpm4_access. */
+#define QDMA_CPM4_GLBL_RNG_SZ_1_REG      0x204   /* ring-size table entry 0 (SW-ctx rng_sz idx 0) */
+#define QDMA_CPM4_DMAP_C2H_DSC_PIDX_REG  0x6408  /* C2H PIDX doorbell base; + qid*0x10 */
+#define QDMA_CPM4_DMAP_CMPT_CIDX_REG     0x640C  /* CMPT CIDX doorbell base; + qid*0x10 */
+#define QDMA_CPM4_PIDX_STEP              0x10
+#define QDMA_CPM4_C2H_RING_ENTRIES       512     /* 8B descriptors; 1 reserved -> 511 credits */
+#define QDMA_CPM4_C2H_RING_BYTES         (QDMA_CPM4_C2H_RING_ENTRIES * 8)
+#define QDMA_CPM4_C2H_CREDIT_INTERVAL_MS 10      /* replenish poll period */
+/* CMPT (completion) host ring: one 8B record per C2H packet + 8B status entry at the end
+ * (en_stat_desc). qsize idx 0 -> GLBL_RNG_SZ_1 (= 512, shared with the credit ring).
+ * The driver never parses records; it only advances CIDX from the status entry's PIDX. */
+#define QDMA_CPM4_CMPT_RING_ENTRIES      QDMA_CPM4_C2H_RING_ENTRIES
+#define QDMA_CPM4_CMPT_RING_BYTES        ((QDMA_CPM4_CMPT_RING_ENTRIES + 1) * 8)
+
+/* FMAP: CPM4 is a DIRECT register (0x400 + func_id*4); CPM5 uses indirect ctx sel 0xc.
+ * CPM4 fields: QID_BASE = bits[10:0], QID_MAX = bits[22:11]. */
+#define QDMA_CPM4_FMAP_BASE_REG    0x400
+#define QDMA_CPM4_FMAP_STEP        0x4
+#define QDMA_CPM4_FMAP_QID_BASE_MASK 0x7FF
+#define QDMA_CPM4_FMAP_QID_MAX_SHIFT 11
+
+/* Completion (CMPT) context VALID bit: CPM4 = word3 BIT(24); CPM5 = word3 BIT(28). */
+#define QDMA_CPM4_CMPT_VALID_WORD 3
+#define QDMA_CPM4_CMPT_VALID_MASK 0x01000000
+#define QDMA_CPM5_CMPT_VALID_WORD 3
+#define QDMA_CPM5_CMPT_VALID_MASK 0x10000000
+
+enum qdma_dev_type {
+    QDMA_DEV_TYPE_CPM5 = 0,  /* eQDMA (V80) -- also the safe default */
+    QDMA_DEV_TYPE_CPM4 = 1,  /* Versal Prime CPM4 (VCK5000) */
+};
+
+/* Per-device QDMA register layout + feature flags, resolved at probe. */
+struct qdma_reg_layout {
+    enum qdma_dev_type dev_type;
+    uint32_t ctx_cmd_reg;
+    uint32_t ctx_data_reg_start;
+    uint32_t ctx_mask_reg_start;
+    int      ctx_n_data_regs;
+    bool     has_host_profile;   /* CPM5 only (regs 0x2c8/0x308 + steering ctx) */
+    bool     has_pfch_bypass;    /* CPM5 only (regs 0x1408/0x140c) */
+    bool     c2h_simple_bypass;  /* C2H prefetch-ctx bypass bit: true=simple(CPM5), false=cache(CPM4) */
+    bool     fmap_indirect;      /* true: FMAP via indirect ctx (CPM5); false: direct reg (CPM4) */
+    uint32_t cmpt_valid_word;
+    uint32_t cmpt_valid_mask;
+};
 
 /*
  * The mapping of control registers to BARs
@@ -650,19 +735,30 @@ struct xdma_engine {
 /// QDMA queue struct; simply a placeholder for some values, so that these can be used later to release queues
 struct qdma_queue {
     /// Queue ID
-    int32_t qid;           
+    int32_t qid;
 
     // Queue state; set to true when initialized, false when removed
-    bool running; 
+    bool running;
 
     /// Direction: C2H (writes) set to 1, H2C (reads) set to 0
-    bool c2h;     
+    bool c2h;
 
     /// Memory mapped or streaming queue
     bool is_mm;
 
     /// Memory mapped channel for MM queues
     uint32_t mm_chn;
+
+    /// CPM4 only: C2H credit ring (see QDMA_CPM4_C2H_RING_* in this file). NULL on CPM5/eQDMA.
+    void       *c2h_ring_vaddr;
+    dma_addr_t  c2h_ring_paddr;
+    uint16_t    c2h_pidx;       /* last PIDX written to the doorbell */
+
+    /// CPM4 only: CMPT (completion) host ring; records ignored, CIDX advanced from the
+    /// status entry so the ring never fills. NULL on CPM5/eQDMA.
+    void       *cmpt_ring_vaddr;
+    dma_addr_t  cmpt_ring_paddr;
+    uint16_t    cmpt_cidx;      /* last CIDX written to the doorbell */
 };
 
 struct ctid_entry {
@@ -1094,6 +1190,13 @@ struct bus_driver_data {
     /// PCI device
     int dev_id;                             /* PCI device ID */
     struct pci_dev *pci_dev;                /* Associated PCI device structure */
+
+    /* Resolved QDMA register layout (CPM4 vs CPM5/eQDMA), set at probe. */
+    struct qdma_reg_layout qreg;
+
+    /* CPM4 only: periodic C2H credit replenish (reads HW-ctx CIDX, tops PIDX back up). */
+    struct delayed_work c2h_credit_work;
+    bool c2h_credit_work_active;
     
     // Char devices metadata
     char vfpga_dev_name[MAX_CHAR_FDEV];     /* Template for vFPGA device names; each vFPGA device will have a unique name based on this template */

--- a/driver/include/platform/pci_qdma.h
+++ b/driver/include/platform/pci_qdma.h
@@ -122,7 +122,13 @@ void unmap_bars(struct bus_driver_data *data, struct pci_dev *pdev);
  *
  * @param data Pointer to the bus driver data structure, containing Coyote device information
  */
-void wait_until_busy_cleared(struct bus_driver_data *bd_data);
+/* Detect CPM4 vs CPM5(eQDMA) and populate bd_data->qreg with the right register layout. */
+void qdma_init_reg_layout(struct bus_driver_data *bd_data);
+
+/* CPM4 C2H credit-ring replenish (delayed work; see QDMA_CPM4_C2H_RING_* in coyote_defs.h). */
+void c2h_credit_work_fn(struct work_struct *work);
+
+int wait_until_busy_cleared(struct bus_driver_data *bd_data);
 
 /**
  * @brief Utility function, clears a given context of a queue
@@ -131,7 +137,7 @@ void wait_until_busy_cleared(struct bus_driver_data *bd_data);
  * @param qid Queue ID
  * @param sel The context to be cleared, options are listed in the QDMA specification from PG347 (v3.4), p301
  */
-void clear_ctx_reg(struct bus_driver_data *bd_data, int32_t qid, int32_t sel);
+int clear_ctx_reg(struct bus_driver_data *bd_data, int32_t qid, int32_t sel);
 
 /**
  * @brief Utility function, invalidates a given context of a queue

--- a/driver/src/platform/pci_qdma.c
+++ b/driver/src/platform/pci_qdma.c
@@ -200,23 +200,91 @@ void unmap_bars(struct bus_driver_data *bd_data, struct pci_dev *pdev) {
     }
 }
 
-void wait_until_busy_cleared(struct bus_driver_data *bd_data) {
-    int busy;
-    do {
-        usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
-        busy = ioread32(bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_CMD_REG) & 0x1;
-    } while (busy);
+void qdma_init_reg_layout(struct bus_driver_data *bd_data) {
+    struct qdma_reg_layout *q = &bd_data->qreg;
+    uint32_t misc_cap, dev_id;
+
+    // GLBL2_MISC_CAP (0x134) is at the same offset on CPM4 and CPM5; bits[31:28] encode
+    // the device type: 1 = Versal CPM4, 2 = Versal CPM5. (AMD dma_ip_drivers,
+    // qdma_access_common.c qdma_fetch_version_details / qdma_soft_reg.h.)
+    misc_cap = ioread32(bd_data->bar[BAR_DMA_CONFIG] + QDMA_GLBL2_MISC_CAP_REG);
+    dev_id = (misc_cap >> QDMA_GLBL2_DEVICE_ID_SHIFT) & QDMA_GLBL2_DEVICE_ID_MASK;
+
+    if (dev_id == QDMA_DEV_ID_CPM4) {
+        q->dev_type            = QDMA_DEV_TYPE_CPM4;
+        q->ctx_cmd_reg         = QDMA_CPM4_CTX_CMD_REG;
+        q->ctx_data_reg_start  = QDMA_CPM4_CTX_DATA_REG_START;
+        q->ctx_mask_reg_start  = QDMA_CPM4_CTX_MASK_REG_START;
+        q->ctx_n_data_regs     = QDMA_CPM4_CTX_N_DATA_REGS;
+        q->has_host_profile    = false;   // host profile is eQDMA/CPM5-only
+        q->has_pfch_bypass     = true;    // ARM the per-queue prefetch slot via 0x1408/0x140c: in
+                                          // SIMPLE mode the arming binds the queue to a slot (enables
+                                          // ring fetch); the slot recycles via the byp_out->byp_in
+                                          // pairing in the shim (PG347 simple-bypass procedure).
+        q->c2h_simple_bypass   = true;    // prefetch-ctx bypass bit = 1 (SIMPLE) -> byp_in_st_sim,
+                                          // matching the v4 pairing bitstream. Manual recipe: arm tag
+                                          // + descriptor loopback (byp_out consumed, byp_in returns
+                                          // the FPGA-addressed descriptor).
+        q->fmap_indirect       = false;   // CPM4 FMAP = direct register 0x400 + func*4
+        q->cmpt_valid_word     = QDMA_CPM4_CMPT_VALID_WORD;
+        q->cmpt_valid_mask     = QDMA_CPM4_CMPT_VALID_MASK;
+        pr_info("QDMA device: Versal CPM4 (GLBL2_MISC_CAP=0x%08x); using CPM4 register layout\n", misc_cap);
+    } else {
+        // Default to CPM5/eQDMA (dev_id == 2, and any unexpected value) -- matches the
+        // historical Coyote/V80 behaviour.
+        q->dev_type            = QDMA_DEV_TYPE_CPM5;
+        q->ctx_cmd_reg         = QDMA_CPM5_CTX_CMD_REG;
+        q->ctx_data_reg_start  = QDMA_CPM5_CTX_DATA_REG_START;
+        q->ctx_mask_reg_start  = QDMA_CPM5_CTX_MASK_REG_START;
+        q->ctx_n_data_regs     = QDMA_CPM5_CTX_N_DATA_REGS;
+        q->has_host_profile    = true;
+        q->has_pfch_bypass     = true;
+        q->c2h_simple_bypass   = true;    // CPM5/eQDMA: simple bypass (SW pfch-tag) -- V80 behaviour
+        q->fmap_indirect       = true;
+        q->cmpt_valid_word     = QDMA_CPM5_CMPT_VALID_WORD;
+        q->cmpt_valid_mask     = QDMA_CPM5_CMPT_VALID_MASK;
+        if (dev_id != QDMA_DEV_ID_CPM5)
+            pr_warn("QDMA device id %u unrecognised (GLBL2_MISC_CAP=0x%08x); defaulting to CPM5/eQDMA layout\n", dev_id, misc_cap);
+        else
+            pr_info("QDMA device: Versal CPM5/eQDMA (GLBL2_MISC_CAP=0x%08x); using eQDMA register layout\n", misc_cap);
+    }
 }
 
-void clear_ctx_reg(struct bus_driver_data *bd_data, int32_t qid, int32_t sel) {
+int wait_until_busy_cleared(struct bus_driver_data *bd_data) {
+    int busy;
+    uint32_t raw;
+    // Bounded poll: if the QDMA config BAR (BAR2) is unreachable, reads return
+    // 0xffffffff, so (raw & 0x1) is permanently 1 -> this used to spin forever and
+    // wedge insmod in D-state. Time out instead so probe fails gracefully. Seen on
+    // the VCK5000 CPM4 bring-up: BAR2 reads all-1s (QDMA CSRs not decoding there).
+    int tries = 0;
+    do {
+        usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
+        raw = ioread32(bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_cmd_reg);
+        busy = raw & 0x1;
+        if (raw == 0xffffffff) {
+            pr_err("QDMA ctx-cmd reg (BAR2+0x%x) reads 0xffffffff -- QDMA config BAR "
+                   "not accessible; aborting queue setup\n", bd_data->qreg.ctx_cmd_reg);
+            return -EIO;
+        }
+        if (++tries > QDMA_CTX_BUSY_MAX_TRIES) {
+            pr_err("QDMA ctx-cmd busy bit never cleared after %d tries (last=0x%08x)\n",
+                   tries, raw);
+            return -ETIMEDOUT;
+        }
+    } while (busy);
+    return 0;
+}
+
+int clear_ctx_reg(struct bus_driver_data *bd_data, int32_t qid, int32_t sel) {
     // Issue clear operation
     int32_t reg_val = QDMA_CTX_BUSY_VAL_DEAULT |
                       ((sel & QDMA_CTX_SEL_MASK) << QDMA_CTX_SEL_SHIFT) |
                       ((QDMA_CTX_CLR & QDMA_CTX_OP_MASK) << QDMA_CTX_OP_SHIFT) |
                       ((qid & QDMA_CTX_QID_MASK) << QDMA_CTX_QID_SHIFT);
-    iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_CMD_REG);
+    iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_cmd_reg);
     wmb();
-    wait_until_busy_cleared(bd_data);
+    return wait_until_busy_cleared(bd_data);
 }
 
 void invalidate_ctx_reg(struct bus_driver_data *bd_data, int32_t qid, int32_t sel) {
@@ -225,7 +293,7 @@ void invalidate_ctx_reg(struct bus_driver_data *bd_data, int32_t qid, int32_t se
                       ((sel & QDMA_CTX_SEL_MASK) << QDMA_CTX_SEL_SHIFT) |
                       ((QDMA_CTX_INV & QDMA_CTX_OP_MASK) << QDMA_CTX_OP_SHIFT) |
                       ((qid & QDMA_CTX_QID_MASK) << QDMA_CTX_QID_SHIFT);
-    iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_CMD_REG);
+    iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_cmd_reg);
     wmb();
     wait_until_busy_cleared(bd_data);
 }
@@ -261,19 +329,49 @@ int enable_queue(struct bus_driver_data *bd_data, int32_t qid, bool c2h, bool is
     tmp_queue->is_mm = is_mm;
     tmp_queue->mm_chn = mm_chn;
     tmp_queue->running = false;
+    tmp_queue->c2h_ring_vaddr = NULL;
+
+    // CPM4 C2H: allocate the credit ring (content unused -> zeroed; provides per-packet
+    // descriptor-fetch credits which CPM4 requires even in simple bypass) and the CMPT
+    // (completion) host ring -- the engine writes one 8B record per packet there (the
+    // silicon-validated completion mechanism); the driver only advances CIDX.
+    if (c2h && bd_data->qreg.dev_type == QDMA_DEV_TYPE_CPM4) {
+        tmp_queue->c2h_ring_vaddr = dma_alloc_coherent(&bd_data->pci_dev->dev,
+                QDMA_CPM4_C2H_RING_BYTES, &tmp_queue->c2h_ring_paddr, GFP_KERNEL);
+        if (!tmp_queue->c2h_ring_vaddr) {
+            pr_err("failed to allocate C2H credit ring for qid %d\n", qid);
+            kfree(tmp_queue);
+            return -ENOMEM;
+        }
+        tmp_queue->cmpt_ring_vaddr = dma_alloc_coherent(&bd_data->pci_dev->dev,
+                QDMA_CPM4_CMPT_RING_BYTES, &tmp_queue->cmpt_ring_paddr, GFP_KERNEL);
+        if (!tmp_queue->cmpt_ring_vaddr) {
+            pr_err("failed to allocate CMPT ring for qid %d\n", qid);
+            dma_free_coherent(&bd_data->pci_dev->dev, QDMA_CPM4_C2H_RING_BYTES,
+                              tmp_queue->c2h_ring_vaddr, tmp_queue->c2h_ring_paddr);
+            kfree(tmp_queue);
+            return -ENOMEM;
+        }
+    }
     
     // Clear any previous contexts
     dbg_info("clearing SW, HW, credit contexts for qid %d", qid);
-    clear_ctx_reg(bd_data, qid, QDMA_CTXT_SELC_DEC_SW_C2H);
-    clear_ctx_reg(bd_data, qid, QDMA_CTXT_SELC_DEC_SW_H2C);
-    clear_ctx_reg(bd_data, qid, QDMA_CTXT_SELC_DEC_HW_C2H);
-    clear_ctx_reg(bd_data, qid, QDMA_CTXT_SELC_DEC_HW_H2C);
-    clear_ctx_reg(bd_data, qid, QDMA_CTXT_SELC_DEC_CR_C2H);
-    clear_ctx_reg(bd_data, qid, QDMA_CTXT_SELC_DEC_CR_H2C);
+    // Abort cleanly if the QDMA config BAR is unreachable (busy bit never clears /
+    // reads 0xffffffff) rather than proceeding with a broken queue setup.
+    if (clear_ctx_reg(bd_data, qid, QDMA_CTXT_SELC_DEC_SW_C2H) ||
+        clear_ctx_reg(bd_data, qid, QDMA_CTXT_SELC_DEC_SW_H2C) ||
+        clear_ctx_reg(bd_data, qid, QDMA_CTXT_SELC_DEC_HW_C2H) ||
+        clear_ctx_reg(bd_data, qid, QDMA_CTXT_SELC_DEC_HW_H2C) ||
+        clear_ctx_reg(bd_data, qid, QDMA_CTXT_SELC_DEC_CR_C2H) ||
+        clear_ctx_reg(bd_data, qid, QDMA_CTXT_SELC_DEC_CR_H2C)) {
+        pr_err("failed to clear QDMA contexts for qid %d (QDMA config BAR unreachable?)\n", qid);
+        kfree(tmp_queue);
+        return -EIO;
+    }
 
     // Initialize the register mask to all 1s, as specified in the docs
-    for (int i = 0; i < QDMA_CTX_N_DATA_REGS; i++) {
-        iowrite32(QDMA_CXT_MASK_DEF_VAL, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_MASK_REG_START + i * 4);
+    for (int i = 0; i < bd_data->qreg.ctx_n_data_regs; i++) {
+        iowrite32(QDMA_CXT_MASK_DEF_VAL, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_mask_reg_start + i * 4);
         wmb();
     }
     usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
@@ -281,7 +379,7 @@ int enable_queue(struct bus_driver_data *bd_data, int32_t qid, bool c2h, bool is
     // Set-up descriptor SW context, based on Table 120 from QDMA specification from PG347 (v3.4) 
     // In the first 32 bits, we want to set function ID to 0 (only one PF) and disable interrupts by setting irq_arm to 0
     // Other bits don't matter to much, set to zero ---> hence, entire reg is zero.
-    iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START);
+    iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start);
     wmb();
 
     // Set bits 32 - 63; in these bits we want to set qen to 1, which enables the queue
@@ -290,24 +388,35 @@ int enable_queue(struct bus_driver_data *bd_data, int32_t qid, bool c2h, bool is
         // Memory-mapped mode --> set bit 63 to 1
         if (mm_chn == 0) {
             // Memory-mapped channel 0 --> set bit 51 to 0
-            iowrite32(0x80040001, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + 4);
+            iowrite32(0x80040001, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + 4);
         } else if (mm_chn == 1) {
             // Memory-mapped channel 1 --> set bit 51 to 1
-            iowrite32(0x800C0001, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + 4);
+            iowrite32(0x800C0001, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + 4);
         } else {
             pr_err("invalid memory-mapped channel %d for qid %d\n", mm_chn, qid);
             goto fail;
         }
     } else {
         // Streaming mode --> set bit 63 to 0
-        iowrite32(0x00040001, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + 4);
+        iowrite32(0x00040001, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + 4);
     }
     wmb();
 
-    // The other fields are reserved, per the QDMA spec, hence set to 0
-    for (int i = 2; i < QDMA_CTX_N_DATA_REGS; i++) {
-        iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + i * 4);
+    // Words 2..N: on CPM4 C2H queues, words 2/3 carry the descriptor-ring base (the credit
+    // ring -- see QDMA_CPM4_C2H_RING_* in coyote_defs.h). W1 rng_sz idx stays 0, pointing at
+    // GLBL_RNG_SZ_1. Elsewhere (CPM5/eQDMA, or H2C) these words are reserved -> 0.
+    if (tmp_queue->c2h_ring_vaddr) {
+        iowrite32((uint32_t)(tmp_queue->c2h_ring_paddr & 0xFFFFFFFF),
+                  bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + 2 * 4);
         wmb();
+        iowrite32((uint32_t)(tmp_queue->c2h_ring_paddr >> 32),
+                  bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + 3 * 4);
+        wmb();
+    } else {
+        for (int i = 2; i < bd_data->qreg.ctx_n_data_regs; i++) {
+            iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + i * 4);
+            wmb();
+        }
     }
 
     // Write the context for this queue
@@ -323,34 +432,30 @@ int enable_queue(struct bus_driver_data *bd_data, int32_t qid, bool c2h, bool is
                 ((QDMA_CTX_WR & QDMA_CTX_OP_MASK) << QDMA_CTX_OP_SHIFT) |
                 ((qid & QDMA_CTX_QID_MASK) << QDMA_CTX_QID_SHIFT);
     }
-    iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_CMD_REG);
+    iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_cmd_reg);
     wmb();
     wait_until_busy_cleared(bd_data);
 
-    // Read the hardware register (idl_stp_b, Table 7 in spec) to check the queue is enabled
-    // Fist, issue read command
-    if (c2h) {
-        reg_val = QDMA_CTX_BUSY_VAL_DEAULT |
-                ((QDMA_CTXT_SELC_DEC_HW_C2H & QDMA_CTX_SEL_MASK) << QDMA_CTX_SEL_SHIFT) |
-                ((QDMA_CTX_RD & QDMA_CTX_OP_MASK) << QDMA_CTX_OP_SHIFT) |
-                ((qid & QDMA_CTX_QID_MASK) << QDMA_CTX_QID_SHIFT);
-    } else {
-        reg_val = QDMA_CTX_BUSY_VAL_DEAULT |
-                ((QDMA_CTXT_SELC_DEC_HW_H2C & QDMA_CTX_SEL_MASK) << QDMA_CTX_SEL_SHIFT) |
-                ((QDMA_CTX_RD & QDMA_CTX_OP_MASK) << QDMA_CTX_OP_SHIFT) |
-                ((qid & QDMA_CTX_QID_MASK) << QDMA_CTX_QID_SHIFT);
-    }
-    iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_CMD_REG);
+    // Verify the queue is enabled by reading back the SOFTWARE context and checking qen
+    // (SW context word[1] bit 0). This is the authoritative queue-enable bit and its
+    // position is identical on CPM4 and CPM5 (AMD dma_ip_drivers, SW_IND_CTXT_DATA_W1_QEN_MASK
+    // = BIT(0)). Previously this read the HARDWARE context idl_stp_b, which is a
+    // descriptor-engine idle/stopped status, not a queue-enable flag.
+    reg_val = QDMA_CTX_BUSY_VAL_DEAULT |
+            (((c2h ? QDMA_CTXT_SELC_DEC_SW_C2H : QDMA_CTXT_SELC_DEC_SW_H2C) & QDMA_CTX_SEL_MASK) << QDMA_CTX_SEL_SHIFT) |
+            ((QDMA_CTX_RD & QDMA_CTX_OP_MASK) << QDMA_CTX_OP_SHIFT) |
+            ((qid & QDMA_CTX_QID_MASK) << QDMA_CTX_QID_SHIFT);
+    iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_cmd_reg);
     wmb();
     wait_until_busy_cleared(bd_data);
-    
-    // Then, read bit 41, corresponding to idl_stp_b
-    reg_val = ioread32(bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + 4);
-    int32_t idl_stp_b = (reg_val >> 9) & 0x1;
-    if (idl_stp_b) {
+
+    // SW context word[1] bit 0 = qen
+    reg_val = ioread32(bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + 4);
+    int32_t qen = reg_val & 0x1;
+    if (qen) {
         dbg_info("enabled software context for qid %d", qid);
     } else {
-        pr_err("failed to enable software context for qid %d, releasing queue", qid);
+        pr_err("failed to enable software context for qid %d (qen=0, sw_ctxt[1]=0x%08x), releasing queue\n", qid, reg_val);
         goto fail;
     }
     
@@ -359,14 +464,24 @@ int enable_queue(struct bus_driver_data *bd_data, int32_t qid, bool c2h, bool is
     clear_ctx_reg(bd_data, qid, QDMA_CTXT_SELC_PFTCH);
     clear_ctx_reg(bd_data, qid, QDMA_CTXT_SELC_WRB);
 
-    // Set up prefetch context for C2H streams in simple bypass mode, per Table 128 in QDMA specification from PG347 (v3.4) 
+    // Set up prefetch context for C2H streams, per Table 128 in QDMA spec (PG347 v3.4).
+    // Prefetch-context word0 bit0 = bypass: 1 = SIMPLE bypass (eQDMA/CPM5 -- fabric provides the
+    // descriptor + a SW-queried pfch_tag from 0x1408/0x140c), 0 = CACHE bypass. CPM4 has no
+    // pfch-tag query registers, so simple bypass is not programmable there; use cache bypass
+    // (bit0=0). (AMD PG302 C2H Stream Modes.) qreg.c2h_simple_bypass encodes this per device.
     if (c2h) {
-        // For bits 31:0, set bypass = 1 (bit 0), port_id = 0 (bits 7:5), and pfch_en = 0 (bit 28)
-        iowrite32(0x1, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START);
+        // word0: bypass bit0 (device-dependent), port_id[7:5]=0, bufsz_idx[4:1]=0 -> selects
+        // C2H_BUF_SZ_0 (0xAB0, programmed to PAGE_SIZE in enable_queues).
+        // CPM4 cache mode additionally needs pfch_en (bit27) = 1: without it, data arriving
+        // before its demand-fetched descriptor completes is DROPPED (HW-verified: DROP_ACC
+        // incremented on the first packet). With pfch_en the engine prefetches ring
+        // descriptors ahead of data using the posted PIDX credits.
+        iowrite32(bd_data->qreg.c2h_simple_bypass ? 0x1 : 0x08000000,
+                  bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start);
         wmb();
 
-        // For bits 63:32, valid = 1 (bit 45)
-        iowrite32(0x2000, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + 4);
+        // word1: valid = 1 (bit 13) -- required in both simple and cache bypass
+        iowrite32(0x2000, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + 4);
         wmb();
 
         // Fire command to write the prefetch context
@@ -375,7 +490,7 @@ int enable_queue(struct bus_driver_data *bd_data, int32_t qid, bool c2h, bool is
                 ((QDMA_CTX_WR & QDMA_CTX_OP_MASK) << QDMA_CTX_OP_SHIFT) |
                 ((qid & QDMA_CTX_QID_MASK) << QDMA_CTX_QID_SHIFT);
    
-        iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_CMD_REG);
+        iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_cmd_reg);
         wmb();
         wait_until_busy_cleared(bd_data);
         
@@ -384,12 +499,12 @@ int enable_queue(struct bus_driver_data *bd_data, int32_t qid, bool c2h, bool is
             ((QDMA_CTXT_SELC_PFTCH & QDMA_CTX_SEL_MASK) << QDMA_CTX_SEL_SHIFT) |
             ((QDMA_CTX_RD & QDMA_CTX_OP_MASK) << QDMA_CTX_OP_SHIFT) |
             ((qid & QDMA_CTX_QID_MASK) << QDMA_CTX_QID_SHIFT);
-        iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_CMD_REG);
+        iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_cmd_reg);
         wmb();
         usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
 
         // Then, read bit 45, corresponding to valid bit
-        reg_val = ioread32(bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + 4);
+        reg_val = ioread32(bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + 4);
         int32_t valid = (reg_val >> 13) & 0x1;
         if (valid) {
             dbg_info("C2H prefetch context set valid, qid %d", qid);
@@ -399,67 +514,116 @@ int enable_queue(struct bus_driver_data *bd_data, int32_t qid, bool c2h, bool is
         }
 
         // For simple bypass mode with commands issued from the FPGA, each command needs
-        // to have a prefetch_tag, as explained on 258 of QDMA specification from PG347 (v3.4) 
+        // to have a prefetch_tag, as explained on 258 of QDMA specification from PG347 (v3.4)
         // This tag can be requested by writing the queue ID to the register QDMA_C2H_PFCH_BYP_QID (0x1408)
         // Then, it can be obtained by reading the register QDMA_C2H_PFCH_BYP_TAG (0x140C)
-        // Finally, we send it to Coyote by writing to the memory-mapped registers of the static layer, 
+        // Finally, we send it to Coyote by writing to the memory-mapped registers of the static layer,
         // so that it can always be used for DMA requests. Bit 31 is set to 1 to indicate it's a valid tag
-        iowrite32(qid, bd_data->bar[BAR_DMA_CONFIG] + QDMA_C2H_PFCH_BYP_QID_REG);
-        wmb();
-        usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
-        int32_t pfch_tag_reg = ioread32(bd_data->bar[BAR_DMA_CONFIG] + QDMA_C2H_PFCH_BYP_TAG_REG);
-        int32_t pfch_qid = ((pfch_tag_reg >> 8) & 0xFFF) - QDMA_WR_QUEUE_START_IDX; // bits 19:8 are the queue ID; substract starting WR queue index because the HW stores them 0, 1 in pfch_tags in qdma_wr_wrapper                    
-        int32_t pfch_tag = pfch_tag_reg & 0x7F;                                     // bits 6:0 are the tag   
-        reg_val = (1 << 31) | (pfch_qid << 8) | pfch_tag;
-        
-        bd_data->stat_cnfg->qdma_pfch_tag = reg_val;
-        wmb();
-        usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
-        bd_data->stat_cnfg->qdma_pfch_tag = 0;  // Reset valid signal
+        //
+        // NOTE: the prefetch-bypass QID/TAG registers (0x1408/0x140c) are eQDMA/CPM5-only;
+        // they do not exist on CPM4 (AMD dma_ip_drivers: absent from qdma_cpm4_reg.h). On CPM4
+        // the C2H simple-bypass prefetch-tag mechanism differs and needs separate bring-up, so
+        // skip it here. TODO(vck5000/CPM4): implement CPM4 C2H bypass prefetch tag; until then,
+        // C2H stream (card->host) bypass transfers are not expected to work on CPM4. H2C
+        // (host->card) MM/stream is independent of this and should work.
+        if (bd_data->qreg.has_pfch_bypass) {
+            iowrite32(qid, bd_data->bar[BAR_DMA_CONFIG] + QDMA_C2H_PFCH_BYP_QID_REG);
+            wmb();
+            usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
+            int32_t pfch_tag_reg = ioread32(bd_data->bar[BAR_DMA_CONFIG] + QDMA_C2H_PFCH_BYP_TAG_REG);
+            int32_t pfch_qid = ((pfch_tag_reg >> 8) & 0xFFF) - QDMA_WR_QUEUE_START_IDX; // bits 19:8 are the queue ID; substract starting WR queue index because the HW stores them 0, 1 in pfch_tags in qdma_wr_wrapper
+            int32_t pfch_tag = pfch_tag_reg & 0x7F;                                     // bits 6:0 are the tag
+            reg_val = (1 << 31) | (pfch_qid << 8) | pfch_tag;
 
-        dbg_info("C2H prefetch tag for qid %d is %d", pfch_qid + QDMA_WR_QUEUE_START_IDX, pfch_tag);
+            bd_data->stat_cnfg->qdma_pfch_tag = reg_val;
+            wmb();
+            usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
+            bd_data->stat_cnfg->qdma_pfch_tag = 0;  // Reset valid signal
+
+            dbg_info("C2H prefetch tag for qid %d is %d", pfch_qid + QDMA_WR_QUEUE_START_IDX, pfch_tag);
+        } else {
+            pr_warn_once("CPM4: skipping C2H prefetch-bypass tag (regs absent); C2H bypass streaming needs CPM4-specific bring-up\n");
+        }
     }
 
-    // Set up completion context, per Table 130 in QDMA specification from PG347 (v3.4) 
-    // For bits 31:0, need to set fnc_id (12:5) to 0 (there's only one PF)
-    iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START);
-    wmb();
+    // Completion (CMPT/WRB) context. Coyote never uses the QDMA completion engine: every C2H
+    // packet is sent with has_cmpt=0 (dis_cmpt=1) and completion is detected fabric-side via
+    // axis_c2h_status; Coyote's "writeback" counters are themselves plain has_cmpt=0 C2H writes.
+    //
+    //  - CPM4: leave the CMPT context CLEARED (it was cleared above). Writing VALID with a zero
+    //    ring base would make any stray completion event DMA to host address 0; with the context
+    //    invalid, a stray event flags WRB_INV_Q instead. Safer, and nothing consults the CMPT
+    //    context for has_cmpt=0 traffic.
+    //  - CPM5/eQDMA (V80): keep the historical Coyote behavior (VALID=1, dir_c2h for C2H queues)
+    //    unchanged, as shipped and validated on that platform. (CPM5 = 6 words, VALID W3 BIT(28).)
+    if (bd_data->qreg.dev_type != QDMA_DEV_TYPE_CPM4) {
+        for (int i = 0; i < bd_data->qreg.ctx_n_data_regs; i++) {
+            iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + i * 4);
+            wmb();
+        }
 
-    // For bits 63:32 and 95:64, there are no fields to be set, hence set to zero.
-    iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + 4);
-    wmb();
-    iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + 8);
-    wmb();
-
-    // For bits 127:96, the valid bit (124) needs to be set
-    iowrite32(0x10000000, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + 12);
-    wmb();
-
-    // For bits 159:128, the dir_c2h bit (146) needs to be set
-    if (c2h) {
-        iowrite32(0x40000, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + 16);
+        // VALID bit (device-specific word/mask)
+        iowrite32(bd_data->qreg.cmpt_valid_mask,
+                  bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + bd_data->qreg.cmpt_valid_word * 4);
         wmb();
+
+        // dir_c2h (bit 146 = word4 bit18) in the wider CPM5 CMPT context
+        if (c2h) {
+            iowrite32(0x40000, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + 16);
+            wmb();
+        }
+
+        // Fire command to write completion context
+        reg_val = QDMA_CTX_BUSY_VAL_DEAULT |
+                    ((QDMA_CTXT_SELC_WRB & QDMA_CTX_SEL_MASK) << QDMA_CTX_SEL_SHIFT) |
+                    ((QDMA_CTX_WR & QDMA_CTX_OP_MASK) << QDMA_CTX_OP_SHIFT) |
+                    ((qid & QDMA_CTX_QID_MASK) << QDMA_CTX_QID_SHIFT);
+
+        iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_cmd_reg);
+        wmb();
+        wait_until_busy_cleared(bd_data);
+        dbg_info("enabled completion context for qid %d", qid);
+    } else if (c2h && tmp_queue->cmpt_ring_vaddr) {
+        // CPM4 with completions ENABLED (the silicon-validated flow): program a real CMPT
+        // context pointing at this queue's host CMPT ring. Field layout per AMD dma_ip_drivers
+        // qdma_cpm4_access (CMPL_CTXT_DATA_W0..W3): W0 = en_stat_desc | trig_mode=1 (EVERY) |
+        // color=1 | qsize_idx=0 (GLBL_RNG_SZ_1=512) | baddr[9:6]<<28; W1 = baddr[41:10];
+        // W2 = baddr[63:42] | desc_size=0 (8B); W3 = VALID (BIT24), pidx/cidx = 0.
+        uint64_t cba = (uint64_t)tmp_queue->cmpt_ring_paddr;
+        uint32_t w0 = (1u << 0)                              /* en_stat_desc */
+                    | (1u << 2)                              /* trig_mode = 1 (every) */
+                    | (1u << 23)                             /* color init 1 */
+                    | ((uint32_t)((cba >> 6) & 0xF) << 28);  /* baddr[9:6] */
+        uint32_t w1 = (uint32_t)((cba >> 10) & 0xFFFFFFFF);  /* baddr[41:10] */
+        uint32_t w2 = (uint32_t)((cba >> 42) & 0x3FFFFF);    /* baddr[63:42]; desc_size=0; pidx_l=0 */
+        uint32_t w3 = (1u << 24);                            /* VALID; pidx_h=0, cidx=0 */
+
+        iowrite32(w0, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + 0 * 4); wmb();
+        iowrite32(w1, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + 1 * 4); wmb();
+        iowrite32(w2, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + 2 * 4); wmb();
+        iowrite32(w3, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + 3 * 4); wmb();
+
+        reg_val = QDMA_CTX_BUSY_VAL_DEAULT |
+                    ((QDMA_CTXT_SELC_WRB & QDMA_CTX_SEL_MASK) << QDMA_CTX_SEL_SHIFT) |
+                    ((QDMA_CTX_WR & QDMA_CTX_OP_MASK) << QDMA_CTX_OP_SHIFT) |
+                    ((qid & QDMA_CTX_QID_MASK) << QDMA_CTX_QID_SHIFT);
+        iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_cmd_reg);
+        wmb();
+        wait_until_busy_cleared(bd_data);
+        tmp_queue->cmpt_cidx = 0;
+        dbg_info("CPM4: CMPT context programmed for qid %d (ring pa %pad)", qid, &tmp_queue->cmpt_ring_paddr);
     } else {
-        iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + 16);
-        wmb();
+        dbg_info("CPM4: CMPT context left cleared for qid %d (H2C queue)", qid);
     }
 
-    // The rest of the fields are zero
-    for (int i = 5; i < QDMA_CTX_N_DATA_REGS; i++) {
-        iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + i * 4);
+    // CPM4 C2H: ring the PIDX doorbell to post the credit ring (after all contexts are set,
+    // matching the reference sequence). PIDX = entries-1 -> 511 credits outstanding.
+    if (tmp_queue->c2h_ring_vaddr) {
+        tmp_queue->c2h_pidx = QDMA_CPM4_C2H_RING_ENTRIES - 1;
+        iowrite32(tmp_queue->c2h_pidx,
+                  bd_data->bar[BAR_DMA_CONFIG] + QDMA_CPM4_DMAP_C2H_DSC_PIDX_REG + qid * QDMA_CPM4_PIDX_STEP);
         wmb();
     }
-    
-    // Fire command to write completion context
-    reg_val = QDMA_CTX_BUSY_VAL_DEAULT |
-                ((QDMA_CTXT_SELC_WRB & QDMA_CTX_SEL_MASK) << QDMA_CTX_SEL_SHIFT) |
-                ((QDMA_CTX_WR & QDMA_CTX_OP_MASK) << QDMA_CTX_OP_SHIFT) |
-                ((qid & QDMA_CTX_QID_MASK) << QDMA_CTX_QID_SHIFT);
-   
-    iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_CMD_REG);
-    wmb();
-    wait_until_busy_cleared(bd_data);
-    dbg_info("enabled completion context for qid %d", qid);
 
     // Set-up complete, add to array of queues
     tmp_queue->running = true;
@@ -475,8 +639,67 @@ fail:
     } else {
         invalidate_ctx_reg(bd_data, qid, QDMA_CTXT_SELC_DEC_SW_H2C);
     }
+    if (tmp_queue->c2h_ring_vaddr)
+        dma_free_coherent(&bd_data->pci_dev->dev, QDMA_CPM4_C2H_RING_BYTES,
+                          tmp_queue->c2h_ring_vaddr, tmp_queue->c2h_ring_paddr);
+    if (tmp_queue->cmpt_ring_vaddr)
+        dma_free_coherent(&bd_data->pci_dev->dev, QDMA_CPM4_CMPT_RING_BYTES,
+                          tmp_queue->cmpt_ring_vaddr, tmp_queue->cmpt_ring_paddr);
     kfree(tmp_queue);
     return -1;
+}
+
+// CPM4 C2H credit replenish: each C2H packet consumes one ring credit; read back the HW
+// context CIDX per queue and top PIDX up to (cidx + entries - 1) so credits never run dry.
+// Runs in process context (indirect ctx reads sleep in the busy-poll).
+void c2h_credit_work_fn(struct work_struct *work) {
+    struct bus_driver_data *bd_data =
+        container_of(to_delayed_work(work), struct bus_driver_data, c2h_credit_work);
+    int32_t reg_val;
+    uint16_t cidx, pidx;
+
+    for (int i = 0; i < bd_data->num_queues; i++) {
+        struct qdma_queue *q = bd_data->queues[i];
+        if (!q || !q->c2h || !q->c2h_ring_vaddr || !q->running)
+            continue;
+        // Indirect READ of the HW C2H context; word0[15:0] = cidx
+        reg_val = QDMA_CTX_BUSY_VAL_DEAULT |
+                ((QDMA_CTXT_SELC_DEC_HW_C2H & QDMA_CTX_SEL_MASK) << QDMA_CTX_SEL_SHIFT) |
+                ((QDMA_CTX_RD & QDMA_CTX_OP_MASK) << QDMA_CTX_OP_SHIFT) |
+                ((q->qid & QDMA_CTX_QID_MASK) << QDMA_CTX_QID_SHIFT);
+        iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_cmd_reg);
+        wmb();
+        if (wait_until_busy_cleared(bd_data))
+            continue;
+        cidx = ioread32(bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start) & 0xFFFF;
+        pidx = (cidx + QDMA_CPM4_C2H_RING_ENTRIES - 1) & 0xFFFF;
+        if (pidx != q->c2h_pidx) {
+            pr_info("c2h credit consumed: qid %d cidx %u -> replenish pidx %u\n", q->qid, cidx, pidx);
+            iowrite32(pidx, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CPM4_DMAP_C2H_DSC_PIDX_REG + q->qid * QDMA_CPM4_PIDX_STEP);
+            wmb();
+            q->c2h_pidx = pidx;
+        }
+
+        // CMPT ring: consume completion records by advancing CIDX. The engine maintains the
+        // ring's status entry (en_stat_desc) whose low 16 bits are the current CMPT PIDX.
+        if (q->cmpt_ring_vaddr) {
+            uint16_t cmpt_pidx = (uint16_t)(*(volatile uint64_t *)((uint8_t *)q->cmpt_ring_vaddr
+                                            + QDMA_CPM4_CMPT_RING_ENTRIES * 8) & 0xFFFF);
+            uint16_t tgt = (uint16_t)((cmpt_pidx + QDMA_CPM4_CMPT_RING_ENTRIES - 1)
+                                      % QDMA_CPM4_CMPT_RING_ENTRIES);
+            if (cmpt_pidx != 0 || q->cmpt_cidx != 0) {
+                if (tgt != q->cmpt_cidx) {
+                    pr_info("cmpt record: qid %d pidx %u -> cidx %u\n", q->qid, cmpt_pidx, tgt);
+                    iowrite32(tgt, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CPM4_DMAP_CMPT_CIDX_REG + q->qid * QDMA_CPM4_PIDX_STEP);
+                    wmb();
+                    q->cmpt_cidx = tgt;
+                }
+            }
+        }
+    }
+
+    if (bd_data->c2h_credit_work_active)
+        schedule_delayed_work(&bd_data->c2h_credit_work, msecs_to_jiffies(QDMA_CPM4_C2H_CREDIT_INTERVAL_MS));
 }
 
 int enable_queues(struct bus_driver_data *bd_data) {
@@ -484,74 +707,103 @@ int enable_queues(struct bus_driver_data *bd_data) {
     int ret_val = 0;
 
     // Initialize the register mask to all 1s, i.e. all bits in data registers are valid    
-    for (int i = 0; i < QDMA_CTX_N_DATA_REGS; i++) {
-        iowrite32(QDMA_CXT_MASK_DEF_VAL, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_MASK_REG_START + i * 4);
+    for (int i = 0; i < bd_data->qreg.ctx_n_data_regs; i++) {
+        iowrite32(QDMA_CXT_MASK_DEF_VAL, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_mask_reg_start + i * 4);
         wmb();
     }
     usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
 
-    // Populate the function map table, per Table 149 in QDMA specification from PG347 (v3.4) 
-    // The QDMA allows to separate queues per physical function, providing full isolation between functions
-    // Currently, Coyote only supports one PF per FPGA, hence we will enable all queues for this PF
-    for (int i = 0; i < QDMA_CTX_N_DATA_REGS; i++) {
-        if (i == 0) {   
-            // Set QID base
-            iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + i * 4);
-            wmb();
-        } else if (i == 1) {
-            // Set maximum queue ID
-            iowrite32(QDMA_N_QUEUES - 1, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + i * 4);
-            wmb();
-        } else {
-            iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + i * 4);
-            wmb();
-        }
+    // CPM4: program the global ring-size table entry 0 (SW-ctx rng_sz idx 0 points here) for
+    // the C2H credit rings.
+    if (bd_data->qreg.dev_type == QDMA_DEV_TYPE_CPM4) {
+        iowrite32(QDMA_CPM4_C2H_RING_ENTRIES, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CPM4_GLBL_RNG_SZ_1_REG);
+        wmb();
+        usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
     }
 
-    int32_t reg_val = QDMA_CTX_BUSY_VAL_DEAULT |
-                      ((QDMA_CTXT_SELC_FMAP & QDMA_CTX_SEL_MASK) << QDMA_CTX_SEL_SHIFT) |
-                      ((QDMA_CTX_WR & QDMA_CTX_OP_MASK) << QDMA_CTX_OP_SHIFT) |
-                      ((0 & QDMA_CTX_QID_MASK) << QDMA_CTX_QID_SHIFT);
-    iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_CMD_REG);
-    wmb();
-    usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
+    // Populate the function map table (FMAP), per Table 149 in QDMA spec (PG347 v3.4).
+    // The QDMA separates queues per physical function; Coyote uses a single PF (func 0) and
+    // enables all queues for it. CPM5/eQDMA programs FMAP via the INDIRECT context (sel=FMAP);
+    // CPM4 programs it as a DIRECT register at 0x400 + func_id*4 (QID_BASE bits[10:0],
+    // QID_MAX bits[22:11]) -- on CPM4 the indirect sel 0xc is QID2VEC, not FMAP.
+    int32_t reg_val;
+    if (bd_data->qreg.fmap_indirect) {
+        for (int i = 0; i < bd_data->qreg.ctx_n_data_regs; i++) {
+            if (i == 0) {
+                // Set QID base
+                iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + i * 4);
+                wmb();
+            } else if (i == 1) {
+                // Set maximum queue ID
+                iowrite32(QDMA_N_QUEUES - 1, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + i * 4);
+                wmb();
+            } else {
+                iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + i * 4);
+                wmb();
+            }
+        }
+
+        reg_val = QDMA_CTX_BUSY_VAL_DEAULT |
+                          ((QDMA_CTXT_SELC_FMAP & QDMA_CTX_SEL_MASK) << QDMA_CTX_SEL_SHIFT) |
+                          ((QDMA_CTX_WR & QDMA_CTX_OP_MASK) << QDMA_CTX_OP_SHIFT) |
+                          ((0 & QDMA_CTX_QID_MASK) << QDMA_CTX_QID_SHIFT);
+        iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_cmd_reg);
+        wmb();
+        usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
+    } else {
+        // CPM4 direct FMAP register for func 0: QID_BASE=0, QID_MAX=QDMA_N_QUEUES-1.
+        uint32_t fmap = (0 & QDMA_CPM4_FMAP_QID_BASE_MASK) |
+                        (((QDMA_N_QUEUES - 1) & 0xFFF) << QDMA_CPM4_FMAP_QID_MAX_SHIFT);
+        iowrite32(fmap, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CPM4_FMAP_BASE_REG + 0 * QDMA_CPM4_FMAP_STEP);
+        wmb();
+        usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
+    }
     dbg_info("initialized function map table");
 
-    // Program host profile (required for MM transfers)
-    // For more details, see: https://adaptivesupport.amd.com/s/article/000035811?language=en_US
-    iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + QDMA_GLBL_VCH_HOST_PROFILE_REG);
-    wmb();
-    usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
-
-    iowrite32(QDMA_DEFAULT_HOST_PROFILE_ID, bd_data->bar[BAR_DMA_CONFIG] + QDMA_GLBL_BRIDGE_HOST_PROFILE_REG);
-    wmb();
-    usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
-    
-    // Set steering interface for MM transfers
-    // To avoid NoC contention, Coyote does as follows:
-    // 1. Register writes (to shell/static layer) are delivered via NOC_0 (configured in cr_pci.tcl)
-    // 2. Memory-mapped PR transfer are delievered via NOC_1 (configured below)
-    for (int i = 0; i < QDMA_CTX_N_DATA_REGS; i++) {
-        if (i == 2) {
-            // Bits [95:64] ---> set steering to NOC_1 for C2H MM (though effectively unused)
-            iowrite32(0x40000000, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + i * 4);
-        } else if (i == 5) {
-            // Bits [191:160] ---> set steering to NOC_1 for H2C MM
-            iowrite32(0x00040000, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + i * 4);
-        } else {
-            iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_DATA_REG_START + i * 4);
-        }
+    // Program host profile (required for MM transfers on eQDMA/CPM5) and the NOC steering
+    // that rides on the host-profile context. Host profile is an eQDMA/CPM5-only feature:
+    // the GLBL_VCH/BRIDGE_HOST_PROFILE registers (0x2c8/0x308) and the HOST_PROFILE indirect
+    // context do NOT exist on CPM4 (AMD dma_ip_drivers: absent from qdma_cpm4_reg.h). On CPM4
+    // the CPM_PCIE_NOC MM routing is fixed by the block design (cr_pci.tcl), so skip this.
+    // TODO(vck5000/CPM4): confirm CPM4 MM NoC steering is handled entirely in HW.
+    if (bd_data->qreg.has_host_profile) {
+        // For more details, see: https://adaptivesupport.amd.com/s/article/000035811?language=en_US
+        iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + QDMA_GLBL_VCH_HOST_PROFILE_REG);
         wmb();
-    }
+        usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
 
-    reg_val = QDMA_CTX_BUSY_VAL_DEAULT |
-                      ((QDMA_CTXT_SELC_HOST_PROFILE & QDMA_CTX_SEL_MASK) << QDMA_CTX_SEL_SHIFT) |
-                      ((QDMA_CTX_WR & QDMA_CTX_OP_MASK) << QDMA_CTX_OP_SHIFT) |
-                      ((QDMA_DEFAULT_HOST_PROFILE_ID & QDMA_CTX_QID_MASK) << QDMA_CTX_QID_SHIFT);
-    iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + QDMA_CTX_CMD_REG);
-    wmb();
-    usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
-    dbg_info("host profile set");
+        iowrite32(QDMA_DEFAULT_HOST_PROFILE_ID, bd_data->bar[BAR_DMA_CONFIG] + QDMA_GLBL_BRIDGE_HOST_PROFILE_REG);
+        wmb();
+        usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
+
+        // Set steering interface for MM transfers
+        // To avoid NoC contention, Coyote does as follows:
+        // 1. Register writes (to shell/static layer) are delivered via NOC_0 (configured in cr_pci.tcl)
+        // 2. Memory-mapped PR transfer are delievered via NOC_1 (configured below)
+        for (int i = 0; i < bd_data->qreg.ctx_n_data_regs; i++) {
+            if (i == 2) {
+                // Bits [95:64] ---> set steering to NOC_1 for C2H MM (though effectively unused)
+                iowrite32(0x40000000, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + i * 4);
+            } else if (i == 5) {
+                // Bits [191:160] ---> set steering to NOC_1 for H2C MM
+                iowrite32(0x00040000, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + i * 4);
+            } else {
+                iowrite32(0, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_data_reg_start + i * 4);
+            }
+            wmb();
+        }
+
+        reg_val = QDMA_CTX_BUSY_VAL_DEAULT |
+                          ((QDMA_CTXT_SELC_HOST_PROFILE & QDMA_CTX_SEL_MASK) << QDMA_CTX_SEL_SHIFT) |
+                          ((QDMA_CTX_WR & QDMA_CTX_OP_MASK) << QDMA_CTX_OP_SHIFT) |
+                          ((QDMA_DEFAULT_HOST_PROFILE_ID & QDMA_CTX_QID_MASK) << QDMA_CTX_QID_SHIFT);
+        iowrite32(reg_val, bd_data->bar[BAR_DMA_CONFIG] + bd_data->qreg.ctx_cmd_reg);
+        wmb();
+        usleep_range(DMA_MIN_SLEEP_CMD, DMA_MIN_SLEEP_CMD);
+        dbg_info("host profile set");
+    } else {
+        pr_info("CPM4: skipping host-profile programming (eQDMA-only); MM NoC routing is fixed in HW\n");
+    }
 
     // Card-to-host (C2H) queues need a prefetch tag to operate in bypass mode
     // The prefetch tag holds up to 6 bits, i.e. 64 different tags can be used
@@ -636,6 +888,14 @@ void disable_queues(struct bus_driver_data *bd_data) {
             }
             // Not really needed, but included for completness sake
             tmp_queue->running = 0;
+
+            // Release the CPM4 C2H credit + CMPT rings, if any
+            if (tmp_queue->c2h_ring_vaddr)
+                dma_free_coherent(&bd_data->pci_dev->dev, QDMA_CPM4_C2H_RING_BYTES,
+                                  tmp_queue->c2h_ring_vaddr, tmp_queue->c2h_ring_paddr);
+            if (tmp_queue->cmpt_ring_vaddr)
+                dma_free_coherent(&bd_data->pci_dev->dev, QDMA_CPM4_CMPT_RING_BYTES,
+                                  tmp_queue->cmpt_ring_vaddr, tmp_queue->cmpt_ring_paddr);
 
             // Release the dynamically allocated memory for this engine
             kfree(tmp_queue);
@@ -815,11 +1075,22 @@ int pci_probe(struct pci_dev *pdev, const struct pci_device_id *id) {
     bd_data->stat_cnfg = ioremap(bd_data->bar_phys_addr[BAR_STAT_CONFIG] + FPGA_STAT_CNFG_OFFS, FPGA_STAT_CNFG_SIZE);
     bd_data->shell_cnfg = ioremap(bd_data->bar_phys_addr[BAR_SHELL_CONFIG] + FPGA_SHELL_CNFG_OFFS, FPGA_SHELL_CNFG_SIZE);
 
+    // Detect CPM4 vs CPM5(eQDMA) and select the correct QDMA register layout before any
+    // QDMA context/register programming. Must run after the DMA-config BAR is mapped.
+    qdma_init_reg_layout(bd_data);
+
     // Set-up the QDMA queues
     ret_val = enable_queues(bd_data);
     if (ret_val) {
         dev_err(&pdev->dev, "error whilst probing DMA queues\n");
         goto err_queues;
+    }
+
+    // CPM4: start the C2H credit replenish work (tops up ring PIDX as packets consume credits)
+    INIT_DELAYED_WORK(&bd_data->c2h_credit_work, c2h_credit_work_fn);
+    if (bd_data->qreg.dev_type == QDMA_DEV_TYPE_CPM4) {
+        bd_data->c2h_credit_work_active = true;
+        schedule_delayed_work(&bd_data->c2h_credit_work, msecs_to_jiffies(QDMA_CPM4_C2H_CREDIT_INTERVAL_MS));
     }
 
     // Assert shell reset
@@ -932,6 +1203,12 @@ end:
 
 void pci_remove(struct pci_dev *pdev) {
     struct bus_driver_data *bd_data = (struct bus_driver_data *) dev_get_drvdata(&pdev->dev);
+
+    // Stop the CPM4 C2H credit replenish work before tearing anything down
+    if (bd_data->c2h_credit_work_active) {
+        bd_data->c2h_credit_work_active = false;
+        cancel_delayed_work_sync(&bd_data->c2h_credit_work);
+    }
 
     // Free HMM chunks
     #ifdef HMM_KERNEL    

--- a/hw/bd/versal/cr_ddr.tcl
+++ b/hw/bd/versal/cr_ddr.tcl
@@ -1,0 +1,136 @@
+######################################################################################
+# This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+# MIT Licence, Copyright (c) 2025, Systems Group, ETH Zurich
+######################################################################################
+#
+# Versal DDR4-over-NoC card memory (VCK5000).
+#
+# The VCK5000 reaches its DDR4 (8 GB/channel, DDR4-3200, 16Gb x16) through the NoC via
+# integrated DDR memory controllers (DDRMC) --- architecturally like the V80's HBM.
+# design_ddr therefore mirrors design_hbm (hw/bd/versal/cr_hbm.tcl): a single axi_noc
+# (inst_ddr_noc) hosts the AXI slave ports (axi_ddr_in_$i, 256-bit, fed by hbm_cc_dwc for
+# CDC + width conversion) AND the integrated DDRMC(s). Keeping the AXI slaves and the MCs
+# in the same NoC means the per-slave CONNECTIONS destinations (MC_$m) resolve locally ---
+# no fragile cross-NoC INI routing. Physical DDR4 + 200 MHz sysclk are exposed to the top.
+#
+# DDRMC config values are taken verbatim from the VCK5000 board-automation DDR4 example
+# (16Gb x16, DDR4-3200AA, 8 GB/channel), which is known-good for this board part.
+#
+# n_mc (physical DDR channels) is read from cfg(n_ddr_chan); it defaults to 1 for a first
+# buildable milestone (8 GB card memory) and scales up to 4 (32 GB). Uses axi_noc:1.0 on
+# 2023.2 (auto-selected to match the installed Vivado).
+
+proc cr_bd_design_ddr { parentCell } {
+  upvar #0 cfg cnfg
+
+  set design_name design_ddr
+  common::send_msg_id "BD_TCL-003" "INFO" "Creating <$design_name> ..."
+  create_bd_design $design_name
+
+  set noc_vlnv [lindex [lsort [get_ipdefs -all xilinx.com:ip:axi_noc:*]] end]
+
+  if { $parentCell eq "" } { set parentCell [get_bd_cells /] }
+  set parentObj [get_bd_cells $parentCell]
+  set oldCurInst [current_bd_instance .]
+  current_bd_instance $parentObj
+
+  set n_mc $cnfg(n_ddr_chan)
+  set n_si $cnfg(n_mem_chan)
+
+  ####################################################################################
+  # Ports
+  ####################################################################################
+  # Physical DDR4 + 200 MHz system clocks (one per channel) --- exposed to the top
+  for {set m 0} {$m < $n_mc} {incr m} {
+    create_bd_intf_port -mode Master -vlnv xilinx.com:interface:ddr4_rtl:1.0 c${m}_ddr4
+    set clk [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 c${m}_sys_clk_0 ]
+    set_property CONFIG.FREQ_HZ {200000000} $clk
+  }
+
+  # AXI-MM card-memory inputs from the shell: 512-bit @ aclk, tied directly to axi_mem
+  # (like the UltraScale+ design_ddr). The Versal NoC NMU accepts 512-bit, so --- unlike the
+  # HBM path (256-bit + hbm_cc_dwc CDC to hclk) --- no width/clock converter is needed.
+  for {set i 0} {$i < $n_si} {incr i} {
+    set p [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 axi_ddr_in_$i ]
+    set_property -dict [ list \
+      CONFIG.FREQ_HZ [expr {int($cnfg(aclk_f) * 1000000)}] \
+      CONFIG.ADDR_WIDTH {64} CONFIG.DATA_WIDTH {512} CONFIG.ID_WIDTH {6} \
+      CONFIG.HAS_BRESP {1} CONFIG.HAS_BURST {1} CONFIG.HAS_CACHE {1} CONFIG.HAS_LOCK {1} \
+      CONFIG.HAS_PROT {1} CONFIG.HAS_QOS {0} CONFIG.HAS_REGION {0} CONFIG.HAS_RRESP {1} \
+      CONFIG.HAS_WSTRB {1} CONFIG.NUM_READ_OUTSTANDING {8} CONFIG.NUM_WRITE_OUTSTANDING {8} \
+      CONFIG.PROTOCOL {AXI4} CONFIG.READ_WRITE_MODE {READ_WRITE} \
+    ] $p
+  }
+
+  # AXI clock for the NoC NMUs (shell clock domain)
+  set aclk [ create_bd_port -dir I -type clk aclk ]
+  set_property CONFIG.FREQ_HZ [expr {int($cnfg(aclk_f) * 1000000)}] $aclk
+
+  ####################################################################################
+  # Single NoC: AXI slaves + integrated DDRMC(s)
+  ####################################################################################
+  set ddr_noc [ create_bd_cell -type ip -vlnv $noc_vlnv inst_ddr_noc ]
+  set_property -dict [ list \
+    CONFIG.NUM_SI $n_si \
+    CONFIG.NUM_MI {0} \
+    CONFIG.NUM_CLKS {1} \
+    CONFIG.NUM_MC $n_mc \
+    CONFIG.NUM_MCP {4} \
+    CONFIG.MC_BOARD_INTRF_EN {true} \
+    CONFIG.MC_COMPONENT_DENSITY {16Gb} \
+    CONFIG.MC_COMPONENT_WIDTH {x16} \
+    CONFIG.MC_MEM_DEVICE_WIDTH {x16} \
+    CONFIG.MC_MEMORY_DEVICE_DENSITY {16Gb} \
+    CONFIG.MC_MEMORY_DENSITY {8GB} \
+    CONFIG.MC_MEMORY_SPEEDGRADE {DDR4-3200AA(22-22-22)} \
+    CONFIG.MC_INPUT_FREQUENCY0 {200.000} \
+    CONFIG.MC_INPUTCLK0_PERIOD {5000} \
+    CONFIG.MC_ROWADDRESSWIDTH {17} \
+    CONFIG.MC_USER_DEFINED_ADDRESS_MAP {17RA-2BA-1BG-10CA} \
+    CONFIG.MC_CHAN_REGION0 {DDR_LOW0} \
+  ] $ddr_noc
+
+  # Per-MC physical DDR4 + sysclk board interfaces
+  for {set m 0} {$m < $n_mc} {incr m} {
+    set_property -dict [ list \
+      CONFIG.CH0_DDR4_${m}_BOARD_INTERFACE "ddr4_sdram_c$m" \
+      CONFIG.sys_clk${m}_BOARD_INTERFACE "ddr4_c${m}_sysclk" \
+    ] $ddr_noc
+  }
+
+  # AXI slaves: each reaches every DDR channel (all-to-all, unified card memory)
+  set dests {}
+  for {set m 0} {$m < $n_mc} {incr m} { lappend dests "MC_$m {read_bw {1720} write_bw {1720} read_avg_burst {4} write_avg_burst {4}}" }
+  for {set i 0} {$i < $n_si} {incr i} {
+    set si [format "S%02d_AXI" $i]
+    set_property -dict [ list CONFIG.CATEGORY {pl} CONFIG.CONNECTIONS [join $dests " "] ] [get_bd_intf_pins inst_ddr_noc/$si]
+    connect_bd_intf_net [get_bd_intf_ports axi_ddr_in_$i] [get_bd_intf_pins inst_ddr_noc/$si]
+  }
+  set _busifs {}
+  for {set i 0} {$i < $n_si} {incr i} { lappend _busifs [format "S%02d_AXI" $i] }
+  set_property CONFIG.ASSOCIATED_BUSIF [join $_busifs ":"] [get_bd_pins inst_ddr_noc/aclk0]
+  connect_bd_net [get_bd_ports aclk] [get_bd_pins inst_ddr_noc/aclk0]
+
+  # Physical DDR4 + sysclk connections
+  for {set m 0} {$m < $n_mc} {incr m} {
+    connect_bd_intf_net [get_bd_intf_ports c${m}_ddr4]      [get_bd_intf_pins inst_ddr_noc/CH0_DDR4_$m]
+    connect_bd_intf_net [get_bd_intf_ports c${m}_sys_clk_0] [get_bd_intf_pins inst_ddr_noc/sys_clk$m]
+  }
+
+  ####################################################################################
+  # Address map: each AXI slave sees the full card memory (n_mc x 8 GB)
+  ####################################################################################
+  for {set i 0} {$i < $n_si} {incr i} {
+    set si [format "S%02d_AXI" $i]
+    foreach seg [get_bd_addr_segs -quiet inst_ddr_noc/$si/C*_DDR_*] {
+      catch { assign_bd_address -target_address_space [get_bd_addr_spaces axi_ddr_in_$i] $seg -force }
+    }
+  }
+
+  current_bd_instance $oldCurInst
+  validate_bd_design
+  save_bd_design
+  close_bd_design $design_name
+  return 0
+}
+# End of cr_bd_design_ddr()

--- a/hw/bd/versal/cr_pci.tcl
+++ b/hw/bd/versal/cr_pci.tcl
@@ -39,12 +39,19 @@ proc cr_bd_design_static { parentCell } {
   # CHECK IPs
   ########################################################################################################
   set bCheckIPs 1
+  # Select the IP versions available in this Vivado (version-adaptive):
+  #   axi_noc     1.1 on 2024.2, 1.0 on 2023.2/2022.1
+  #   versal_cips 3.4 on 2023.2/2024.2, 3.2 on 2022.1  (the VCK5000 CPM4 QDMA only brings up
+  #               its PCIe under 2022.1/CIPS 3.2, so the vck5000 flow must run on 2022.1)
+  set noc_vlnv  [lindex [lsort [get_ipdefs -all xilinx.com:ip:axi_noc:*]] end]
+  set cips_vlnv [lindex [lsort [get_ipdefs -all xilinx.com:ip:versal_cips:*]] end]
+
   if { $bCheckIPs == 1 } {
-    set list_check_ips "\ 
+    set list_check_ips "\
       xilinx.com:ip:proc_sys_reset:5.0\
       xilinx.com:ip:util_vector_logic:2.0\
-      xilinx.com:ip:versal_cips:3.4\
-      xilinx.com:ip:axi_noc:1.1\
+      $cips_vlnv\
+      $noc_vlnv\
       xilinx.com:ip:smartconnect:1.0\
       xilinx.com:ip:xlconstant:1.1\
     "
@@ -141,7 +148,8 @@ proc cr_bd_design_static { parentCell } {
     CONFIG.PROTOCOL {AXI4} \
   ] $axi_debug_hub
 
-  # QDMA status
+  # QDMA status --- boundary kept identical to the V80 (eqdma_qsts). On the VCK5000 the
+  # H2C status is derived internally from the CPM4 traffic-manager descriptor status.
   set h2c_status [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:eqdma_qsts_rtl:1.0 h2c_status ]
   set c2h_status [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:qdma_c2h_status_rtl:1.0 c2h_status ]
 
@@ -153,6 +161,10 @@ proc cr_bd_design_static { parentCell } {
   set pcie_gt [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:gt_rtl:1.0 pcie_gt ]
 
   # Data streams
+  # NOTE: design_static's external boundary is kept identical across devices (eQDMA-style,
+  # matching the V80). On the VCK5000 (CPM4, plain QDMA) the differences are converted
+  # internally within this BD (see the vck5000 adapter block below), so the static_top
+  # template and the qdma_rd/wr wrappers are device-independent.
   set s_axis_c2h [ create_bd_intf_port -mode Slave -vlnv xilinx.com:display_eqdma:s_axis_c2h_rtl:1.0 s_axis_c2h ]
   set m_axis_h2c [ create_bd_intf_port -mode Master -vlnv xilinx.com:display_eqdma:m_axis_h2c_rtl:1.0 m_axis_h2c ]
 
@@ -165,6 +177,14 @@ proc cr_bd_design_static { parentCell } {
 
   # User interrupts
   set usr_irq [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:qdma_usr_irq_rtl:1.0 usr_irq ]
+
+  # VCK5000 only: physical DDR4 + 200 MHz system clock for the integrated DDR MC that backs
+  # the CPM_PCIE_NOC path (see axi_noc_0 below). These are the only added design_static ports.
+  if {$cnfg(fdev) eq "vck5000"} {
+    create_bd_intf_port -mode Master -vlnv xilinx.com:interface:ddr4_rtl:1.0 c0_ddr4
+    set c0_sys_clk_0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 c0_sys_clk_0 ]
+    set_property CONFIG.FREQ_HZ {200000000} $c0_sys_clk_0
+  }
 
 ########################################################################################################
 # Create ports
@@ -210,7 +230,7 @@ proc cr_bd_design_static { parentCell } {
     # If using a single Gen5x8 QDMA controller, PCIE1 must be selected to ensure compliance with PCI SIG
     # For more details, see: https://xilinx.github.io/AVED/latest/AVED%2BV80%2B-%2BCIPS%2BConfiguration.html#cpm5-basic-configuration
     if {$cnfg(pcie_gen) eq 5} {
-      set versal_cips_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:versal_cips:3.4 versal_cips_0 ]
+      set versal_cips_0 [ create_bd_cell -type ip -vlnv $cips_vlnv versal_cips_0 ]
       set_property -dict [list \
         CONFIG.BOOT_MODE {Custom} \
         CONFIG.CLOCK_MODE {Custom} \
@@ -289,7 +309,7 @@ proc cr_bd_design_static { parentCell } {
       ] $versal_cips_0
     } elseif {$cnfg(pcie_gen) eq 4} {
       # And, if using a Gen4x16 QDMA controller, PCIE0 must be selected
-      set versal_cips_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:versal_cips:3.4 versal_cips_0 ]
+      set versal_cips_0 [ create_bd_cell -type ip -vlnv $cips_vlnv versal_cips_0 ]
       set_property -dict [list \
         CONFIG.BOOT_MODE {Custom} \
         CONFIG.CLOCK_MODE {Custom} \
@@ -369,7 +389,87 @@ proc cr_bd_design_static { parentCell } {
     } else {
       puts "ERROR: Unsupported PCIe configuration: Gen$cnfg(pcie_gen). Supported configurations for V80 are Gen4x16 and Gen5x8."
       exit 1
-    }   
+    }
+  } elseif {$cnfg(fdev) eq "vck5000"} {
+    # VCK5000 (Versal VC1902) uses CPM4 (not CPM5). CPM4 QDMA is exposed via PCIE0 in
+    # QDMA functional mode, giving the same descriptor-bypass + AXI_MM_and_AXI_Stream
+    # interface family Coyote expects. The VCK5000 CPM4 link is PCIe Gen4x8 (X8, 16 GT/s).
+    #
+    # Built on versal_cips 3.2 (Vivado 2022.1) -- the only version that brings up the CPM4
+    # QDMA PCIe on this board. The CPM_PCIE0_PF0_BAR{0,4}_QDMA_STEERING sub-keys are 3.4-only
+    # (3.2 emits "Invalid parameter ... Ignoring") and are intentionally omitted: on 3.2 the
+    # BAR-to-CPM_PCIE_NOC steering is implicit via PS_USE_PS_NOC_PCI_0 {1} below plus the
+    # axi_noc_0 S00/S01 CONNECTIONS/DEST_IDS and the assign_bd_address mappings. This matches
+    # the proven 2022.1/3.2 CPM4-QDMA config (opendpu cips_config.tcl), which also has no STEERING.
+    set versal_cips_0 [ create_bd_cell -type ip -vlnv $cips_vlnv versal_cips_0 ]
+    set_property -dict [list \
+      CONFIG.BOOT_MODE {Custom} \
+      CONFIG.CLOCK_MODE {Custom} \
+      CONFIG.CPM_CONFIG { \
+        CPM_PCIE1_MODES {None} \
+        CPM_PCIE0_FUNCTIONAL_MODE {QDMA} \
+        CPM_PCIE0_MODES {DMA} \
+        CPM_PCIE0_MODE_SELECTION {Advanced} \
+        CPM_PCIE0_DMA_INTF {AXI_MM_and_AXI_Stream} \
+        CPM_PCIE0_DSC_BYPASS_RD {1} \
+        CPM_PCIE0_DSC_BYPASS_WR {1} \
+        CPM_PCIE0_MSI_X_OPTIONS {MSI-X_Internal} \
+        CPM_PCIE0_LANE_REVERSAL_EN {0} \
+        CPM_PCIE0_PF0_BAR0_QDMA_64BIT {1} \
+        CPM_PCIE0_PF0_BAR0_QDMA_AXCACHE {0} \
+        CPM_PCIE0_PF0_BAR0_QDMA_PREFETCHABLE {1} \
+        CPM_PCIE0_PF0_BAR0_QDMA_SCALE {Megabytes} \
+        CPM_PCIE0_PF0_BAR0_QDMA_SIZE {1} \
+        CPM_PCIE0_PF0_BAR0_QDMA_TYPE {AXI_Bridge_Master} \
+        CPM_PCIE0_PF0_BAR1_QDMA_AXCACHE {0} \
+        CPM_PCIE0_PF0_BAR2_QDMA_AXCACHE {0} \
+        CPM_PCIE0_PF0_BAR2_QDMA_64BIT {1} \
+        CPM_PCIE0_PF0_BAR2_QDMA_ENABLED {1} \
+        CPM_PCIE0_PF0_BAR2_QDMA_TYPE {DMA} \
+        CPM_PCIE0_PF0_BAR3_QDMA_AXCACHE {0} \
+        CPM_PCIE0_PF0_BAR4_QDMA_64BIT {1} \
+        CPM_PCIE0_PF0_BAR4_QDMA_AXCACHE {0} \
+        CPM_PCIE0_PF0_BAR4_QDMA_ENABLED {1} \
+        CPM_PCIE0_PF0_BAR4_QDMA_PREFETCHABLE {1} \
+        CPM_PCIE0_PF0_BAR4_QDMA_SCALE {Megabytes} \
+        CPM_PCIE0_PF0_BAR4_QDMA_SIZE {256} \
+        CPM_PCIE0_PF0_BAR5_QDMA_AXCACHE {0} \
+        CPM_PCIE0_PF0_MSIX_CAP_TABLE_SIZE {0x1F} \
+        CPM_PCIE0_PF0_PCIEBAR2AXIBAR_QDMA_0 {0x020100000000} \
+        CPM_PCIE0_PF0_PCIEBAR2AXIBAR_QDMA_2 {0x0} \
+        CPM_PCIE0_PF0_PCIEBAR2AXIBAR_QDMA_4 {0x020800000000} \
+        CPM_PCIE0_PL_LINK_CAP_MAX_LINK_WIDTH {X16} \
+        CPM_PCIE0_MAX_LINK_SPEED {8.0_GT/s} \
+        CPM_PCIE0_REF_CLK_FREQ {100_MHz} \
+        PS_USE_PS_NOC_PCI_0 {1} \
+      } \
+      CONFIG.DEVICE_INTEGRITY_MODE {Custom} \
+      CONFIG.PS_PMC_CONFIG { \
+        BOOT_MODE {Custom} \
+        CLOCK_MODE {Custom} \
+        DESIGN_MODE {1} \
+        DEVICE_INTEGRITY_MODE {Custom} \
+        PCIE_APERTURES_DUAL_ENABLE {0} \
+        PCIE_APERTURES_SINGLE_ENABLE {1} \
+        PMC_CRP_PL0_REF_CTRL_FREQMHZ {33.3333333} \
+        PMC_REF_CLK_FREQMHZ {33.333333} \
+        PMC_USE_NOC_PMC_AXI0 {1} \
+        PMC_USE_PMC_NOC_AXI0 {1} \
+        PS_USE_STARTUP {1} \
+        PS_BOARD_INTERFACE {Custom} \
+        PS_CRL_CPM_TOPSW_REF_CTRL_FREQMHZ {775} \
+        PS_PCIE1_PERIPHERAL_ENABLE {1} \
+        PS_PCIE2_PERIPHERAL_ENABLE {0} \
+        PS_PCIE_EP_RESET1_IO {PMC_MIO 38} \
+        PS_PCIE_RESET {ENABLE 1} \
+        PS_USE_PMCPL_CLK0 {1} \
+        SMON_ALARMS {Set_Alarms_On} \
+        SMON_ENABLE_TEMP_AVERAGING {0} \
+        SMON_OT {{THRESHOLD_LOWER -25} {THRESHOLD_UPPER 125}} \
+        SMON_TEMP_AVERAGING_SAMPLES {0} \
+        SMON_USER_TEMP {{THRESHOLD_LOWER 0} {THRESHOLD_UPPER 125} {USER_ALARM_TYPE window}} \
+      } \
+    ] $versal_cips_0
   } else {
     puts "ERROR: Unsupported FPGA part: $cnfg(fdev)"
     exit 1
@@ -378,15 +478,48 @@ proc cr_bd_design_static { parentCell } {
   # AXI NoC
   # The NoC is used to route AXI-MM interfaces from the QDMA to the shell
   # Additionally, it will perform clock-domain crossing, reducing the frequency from 1000 MHz to shell frequency
-  set axi_noc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_noc:1.1 axi_noc_0 ]
-  set_property -dict [list \
-    CONFIG.MI_SIDEBAND_PINS {0} \
-    CONFIG.NUM_CLKS {5} \
-    CONFIG.NUM_HBM_BLI {0} \
-    CONFIG.NUM_MI {4} \
-    CONFIG.NUM_SI {3} \
-    CONFIG.SI_SIDEBAND_PINS {} \
-  ] $axi_noc_0
+  set axi_noc_0 [ create_bd_cell -type ip -vlnv $noc_vlnv axi_noc_0 ]
+  if {$cnfg(fdev) eq "vck5000"} {
+    # VCK5000 CPM4: the CPM_PCIE_NOC path MUST reach a real NoC-backed memory target
+    # (integrated DDR memory controller + a small BRAM) or the CPM enumerates as rev-ff
+    # ghost functions. So axi_noc_0 hosts an integrated DDRMC (MC_0, 8 GB DDR4-3200 16Gb x16,
+    # board interfaces ddr4_sdram_c0 / ddr4_c0_sysclk) plus one extra MI (M04_AXI) that drives
+    # an on-chip BRAM. MC config is taken verbatim from cr_ddr.tcl (known-good on this board
+    # part / Vivado 2023.2). NUM_MI 4 -> 5 (add M04_AXI BRAM); NUM_MC 0 -> 1 (+ NUM_MCP 4).
+    set_property -dict [list \
+      CONFIG.MI_SIDEBAND_PINS {0} \
+      CONFIG.NUM_CLKS {5} \
+      CONFIG.NUM_HBM_BLI {0} \
+      CONFIG.NUM_MI {5} \
+      CONFIG.NUM_SI {3} \
+      CONFIG.NUM_MC {1} \
+      CONFIG.NUM_MCP {4} \
+      CONFIG.SI_SIDEBAND_PINS {} \
+      CONFIG.MC_BOARD_INTRF_EN {true} \
+      CONFIG.MC_COMPONENT_DENSITY {16Gb} \
+      CONFIG.MC_COMPONENT_WIDTH {x16} \
+      CONFIG.MC_MEM_DEVICE_WIDTH {x16} \
+      CONFIG.MC_MEMORY_DEVICE_DENSITY {16Gb} \
+      CONFIG.MC_MEMORY_DENSITY {8GB} \
+      CONFIG.MC_MEMORY_SPEEDGRADE {DDR4-3200AA(22-22-22)} \
+      CONFIG.MC_INPUT_FREQUENCY0 {200.000} \
+      CONFIG.MC_INPUTCLK0_PERIOD {5000} \
+      CONFIG.MC_ROWADDRESSWIDTH {17} \
+      CONFIG.MC_USER_DEFINED_ADDRESS_MAP {17RA-2BA-1BG-10CA} \
+      CONFIG.MC_CHAN_REGION0 {DDR_LOW0} \
+      CONFIG.CH0_DDR4_0_BOARD_INTERFACE {ddr4_sdram_c0} \
+      CONFIG.sys_clk0_BOARD_INTERFACE {ddr4_c0_sysclk} \
+    ] $axi_noc_0
+  } else {
+    set_property -dict [list \
+      CONFIG.MI_SIDEBAND_PINS {0} \
+      CONFIG.NUM_CLKS {5} \
+      CONFIG.NUM_HBM_BLI {0} \
+      CONFIG.NUM_MI {4} \
+      CONFIG.NUM_SI {3} \
+      CONFIG.SI_SIDEBAND_PINS {} \
+    ] $axi_noc_0
+  }
 
   set_property -dict [ list \
     CONFIG.APERTURES {{0x201_0000_0000 1G}} \
@@ -413,21 +546,52 @@ proc cr_bd_design_static { parentCell } {
     CONFIG.CATEGORY {pl} \
   ] [get_bd_intf_pins /axi_noc_0/M03_AXI]
 
+  if {$cnfg(fdev) eq "vck5000"} {
+    # M04_AXI -> on-chip BRAM (512-bit). Placed at a distinct aperture, away from the
+    # register apertures (axi_cnfg 0x201.., axi_main 0x208.., debug 0x202_4..).
+    set_property -dict [ list \
+      CONFIG.APERTURES {{0x203_0000_0000 1G}} \
+      CONFIG.DATA_WIDTH {512} \
+      CONFIG.CATEGORY {pl} \
+    ] [get_bd_intf_pins /axi_noc_0/M04_AXI]
+  }
+
   # CPM_PCIE_NOC_0 is used for shell and static layer registers
-  set_property -dict [ list \
-    CONFIG.CONNECTIONS {M00_AXI {read_bw {8} write_bw {8} read_avg_burst {4} write_avg_burst {4}} M01_AXI {read_bw {8} write_bw {8} read_avg_burst {4} write_avg_burst {4}}} \
-    CONFIG.DEST_IDS {M01_AXI:0x0:M00_AXI:0x40} \
-    CONFIG.NOC_PARAMS {} \
-    CONFIG.CATEGORY {ps_pcie} \
-  ] [get_bd_intf_pins /axi_noc_0/S00_AXI]
+  if {$cnfg(fdev) eq "vck5000"} {
+    # Additionally reaches the integrated DDR (MC_0) and the BRAM (M04_AXI) so the CPM4
+    # bridge/QDMA master has a live NoC-backed memory target (required for enumeration).
+    set_property -dict [ list \
+      CONFIG.CONNECTIONS {M00_AXI {read_bw {8} write_bw {8} read_avg_burst {4} write_avg_burst {4}} M01_AXI {read_bw {8} write_bw {8} read_avg_burst {4} write_avg_burst {4}} M04_AXI {read_bw {1720} write_bw {1720} read_avg_burst {4} write_avg_burst {4}} MC_0 {read_bw {1720} write_bw {1720} read_avg_burst {4} write_avg_burst {4}}} \
+      CONFIG.DEST_IDS {M01_AXI:0x0:M00_AXI:0x40:M04_AXI:0x100:MC_0:0x140} \
+      CONFIG.NOC_PARAMS {} \
+      CONFIG.CATEGORY {ps_pcie} \
+    ] [get_bd_intf_pins /axi_noc_0/S00_AXI]
+  } else {
+    set_property -dict [ list \
+      CONFIG.CONNECTIONS {M00_AXI {read_bw {8} write_bw {8} read_avg_burst {4} write_avg_burst {4}} M01_AXI {read_bw {8} write_bw {8} read_avg_burst {4} write_avg_burst {4}}} \
+      CONFIG.DEST_IDS {M01_AXI:0x0:M00_AXI:0x40} \
+      CONFIG.NOC_PARAMS {} \
+      CONFIG.CATEGORY {ps_pcie} \
+    ] [get_bd_intf_pins /axi_noc_0/S00_AXI]
+  }
 
   # CPM_PCIE_NOC_1 is used for QDMA MM data transfers
-  set_property -dict [ list \
-    CONFIG.CONNECTIONS {M02_AXI {read_bw {6400} write_bw {6400} read_avg_burst {64} write_avg_burst {64}}} \
-    CONFIG.DEST_IDS {M02_AXI:0x80} \
-    CONFIG.NOC_PARAMS {} \
-    CONFIG.CATEGORY {ps_pcie} \
-  ] [get_bd_intf_pins /axi_noc_0/S01_AXI]
+  if {$cnfg(fdev) eq "vck5000"} {
+    # Also reaches the integrated DDR (MC_0) and the BRAM (M04_AXI) --- the QDMA MM data path.
+    set_property -dict [ list \
+      CONFIG.CONNECTIONS {M02_AXI {read_bw {6400} write_bw {6400} read_avg_burst {64} write_avg_burst {64}} M04_AXI {read_bw {1720} write_bw {1720} read_avg_burst {4} write_avg_burst {4}} MC_0 {read_bw {1720} write_bw {1720} read_avg_burst {4} write_avg_burst {4}}} \
+      CONFIG.DEST_IDS {M02_AXI:0x80:M04_AXI:0x100:MC_0:0x140} \
+      CONFIG.NOC_PARAMS {} \
+      CONFIG.CATEGORY {ps_pcie} \
+    ] [get_bd_intf_pins /axi_noc_0/S01_AXI]
+  } else {
+    set_property -dict [ list \
+      CONFIG.CONNECTIONS {M02_AXI {read_bw {6400} write_bw {6400} read_avg_burst {64} write_avg_burst {64}}} \
+      CONFIG.DEST_IDS {M02_AXI:0x80} \
+      CONFIG.NOC_PARAMS {} \
+      CONFIG.CATEGORY {ps_pcie} \
+    ] [get_bd_intf_pins /axi_noc_0/S01_AXI]
+  }
 
   # PMC_NOC is used for configuring the Debug Hub IP (which sets up ILAs, VIOs etc.)
   set_property -dict [ list \
@@ -449,9 +613,17 @@ proc cr_bd_design_static { parentCell } {
    CONFIG.ASSOCIATED_BUSIF {S02_AXI} \
   ] [get_bd_pins /axi_noc_0/aclk2]
 
-  set_property -dict [ list \
-    CONFIG.ASSOCIATED_BUSIF {M00_AXI:M01_AXI:M03_AXI} \
-  ] [get_bd_pins /axi_noc_0/aclk3]
+  if {$cnfg(fdev) eq "vck5000"} {
+    # Shell-clock domain masters: registers (M00/M01), debug hub (M03) and the BRAM (M04).
+    # The integrated DDR MC needs no aclk (it runs off sys_clk0).
+    set_property -dict [ list \
+      CONFIG.ASSOCIATED_BUSIF {M00_AXI:M01_AXI:M03_AXI:M04_AXI} \
+    ] [get_bd_pins /axi_noc_0/aclk3]
+  } else {
+    set_property -dict [ list \
+      CONFIG.ASSOCIATED_BUSIF {M00_AXI:M01_AXI:M03_AXI} \
+    ] [get_bd_pins /axi_noc_0/aclk3]
+  }
 
   set_property -dict [ list \
    CONFIG.ASSOCIATED_BUSIF {M02_AXI} \
@@ -466,6 +638,22 @@ proc cr_bd_design_static { parentCell } {
   set_property CONFIG.NUM_SI {1} $smartconnect_1
   set_property CONFIG.ADVANCED_PROPERTIES {__experimental_features__ {disable_low_area_mode 1} __view__ {functional {S00_Entry {SUPPORTS_WRAP 1 SUPPORTS_NARROW_BURST 1}}}} $smartconnect_1
 
+  # VCK5000 only: on-chip BRAM reached from the CPM_PCIE_NOC path via axi_noc_0/M04_AXI.
+  # 512-bit AXI BRAM controller + 512 KB URAM-backed memory (mirrors mini_bd.tcl's pl_mem).
+  if {$cnfg(fdev) eq "vck5000"} {
+    set bram_ctrl_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_bram_ctrl:4.1 bram_ctrl_0 ]
+    set_property -dict [ list \
+      CONFIG.DATA_WIDTH {512} \
+      CONFIG.SINGLE_PORT_BRAM {1} \
+    ] $bram_ctrl_0
+    set bram_mem_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:emb_mem_gen:1.0 bram_mem_0 ]
+    set_property -dict [ list \
+      CONFIG.MEMORY_PRIMITIVE {URAM} \
+      CONFIG.MEMORY_TYPE {Single_Port_RAM} \
+    ] $bram_mem_0
+    connect_bd_intf_net [get_bd_intf_pins bram_ctrl_0/BRAM_PORTA] [get_bd_intf_pins bram_mem_0/BRAM_PORTA]
+  }
+
   # Main clock gen
   create_bd_cell -type ip -vlnv xilinx.com:ip:clk_wizard:1.0 clk_wiz_0
   set cmd "set_property -dict \[list \
@@ -479,10 +667,68 @@ proc cr_bd_design_static { parentCell } {
 ########################################################################################################
 # Create interface connections
 ########################################################################################################
-  if {$cnfg(pcie_gen) eq 5} {
+  if {$cnfg(fdev) eq "vck5000"} {
+    # VCK5000 CPM4 QDMA (PCIE0). Directly-mappable interfaces connect straight through; the
+    # eQDMA<->QDMA data/status/completion differences are converted internally by cpm4_qdma_shim
+    # so design_static's boundary stays identical to the V80.
+    connect_bd_intf_net [get_bd_intf_ports pcie_clk] [get_bd_intf_pins versal_cips_0/gt_refclk0]
+    connect_bd_intf_net [get_bd_intf_ports pcie_gt] [get_bd_intf_pins versal_cips_0/PCIE0_GT]
+    connect_bd_intf_net [get_bd_intf_ports dsc_bypass_h2c] [get_bd_intf_pins versal_cips_0/dma0_h2c_byp_in_st]
+    connect_bd_intf_net [get_bd_intf_ports usr_irq] [get_bd_intf_pins versal_cips_0/dma0_usr_irq]
+
+    # Internal CPM4 <-> eQDMA shim (hw/hdl/static/cpm4_qdma_shim.v, added via cr_static)
+    create_bd_cell -type module -reference cpm4_qdma_shim cpm4_shim_0
+    # Boundary (eQDMA-style) interfaces -> design_static ports
+    connect_bd_intf_net [get_bd_intf_ports m_axis_h2c]     [get_bd_intf_pins cpm4_shim_0/m_axis_h2c]
+    connect_bd_intf_net [get_bd_intf_ports s_axis_c2h]     [get_bd_intf_pins cpm4_shim_0/s_axis_c2h]
+    connect_bd_intf_net [get_bd_intf_ports h2c_status]     [get_bd_intf_pins cpm4_shim_0/h2c_status]
+    connect_bd_intf_net [get_bd_intf_ports c2h_status]     [get_bd_intf_pins cpm4_shim_0/c2h_status]
+    connect_bd_intf_net [get_bd_intf_ports dsc_bypass_c2h] [get_bd_intf_pins cpm4_shim_0/dsc_bypass_c2h]
+    connect_bd_intf_net [get_bd_intf_ports dsc_pr]         [get_bd_intf_pins cpm4_shim_0/dsc_pr]
+
+    # ---- shim CPM4-side scalars <-> versal_cips_0 QDMA pins ----
+    # H2C data
+    foreach s {tdata tvalid tlast tready qid port_id err mdata mty zero_byte} {
+      connect_bd_net [get_bd_pins cpm4_shim_0/cpm_h2c_$s] [get_bd_pins versal_cips_0/dma0_m_axis_h2c_$s]
+    }
+    # C2H data (dpar tied inside shim)
+    foreach s {tdata tvalid tlast tready mty dpar ctrl_marker ctrl_port_id ctrl_len ctrl_qid ctrl_dis_cmpt} {
+      connect_bd_net [get_bd_pins cpm4_shim_0/cpm_c2h_$s] [get_bd_pins versal_cips_0/dma0_s_axis_c2h_$s]
+    }
+    # C2H completion stream: one 8B CMPT record per packet (shim-generated; consumed by the
+    # driver's host CMPT ring -- the silicon-validated completion mechanism)
+    foreach s {data dpar size tlast tvalid tready} {
+      connect_bd_net [get_bd_pins cpm4_shim_0/cpm_c2h_cmpt_$s] [get_bd_pins versal_cips_0/dma0_s_axis_c2h_cmpt_$s]
+    }
+    # C2H command / descriptor bypass  (shim -> CPM4 dma0_c2h_byp_in_st_sim -- SIMPLE bypass,
+    # armed-slot flow). SW arms the per-queue prefetch slot via 0x1408/0x140c; the shim submits
+    # the FPGA-addressed descriptor on byp_in with an outstanding-limit of ONE (a byp_in beat
+    # while the slot is busy is silently lost -- HW-verified); the slot frees on the
+    # axis_c2h_status pulse. Must agree with prefetch-ctx bypass bit = 1 (simple) in the driver.
+    foreach s {addr error func port_id qid ready valid} {
+      connect_bd_net [get_bd_pins cpm4_shim_0/cpm_c2h_byp_$s] [get_bd_pins versal_cips_0/dma0_c2h_byp_in_st_sim_$s]
+    }
+    # C2H descriptor-bypass OUT (CPM4 -> shim): carries the per-packet marker responses that
+    # synthesize the boundary c2h_status (CPM4's axis_c2h_status does not pulse in bypass mode)
+    foreach s {valid mrkr_rsp st_mm qid error ready} {
+      connect_bd_net [get_bd_pins cpm4_shim_0/cpm_c2h_byp_out_$s] [get_bd_pins versal_cips_0/dma0_c2h_byp_out_$s]
+    }
+    # PR MM descriptor  (shim -> CPM4 dma0_h2c_byp_in_mm)
+    foreach s {radr wadr cidx error func len mrkr_req port_id qid ready sdi valid} {
+      connect_bd_net [get_bd_pins cpm4_shim_0/cpm_pr_$s] [get_bd_pins versal_cips_0/dma0_h2c_byp_in_mm_$s]
+    }
+    # C2H status (CPM4 -> shim)
+    foreach s {drop qid valid} {
+      connect_bd_net [get_bd_pins cpm4_shim_0/cpm_c2h_sts_$s] [get_bd_pins versal_cips_0/dma0_axis_c2h_status_$s]
+    }
+    # H2C descriptor-bypass output = marker response = H2C completion (CPM4 -> shim)
+    foreach s {valid mrkr_rsp error qid port_id ready} {
+      connect_bd_net [get_bd_pins cpm4_shim_0/cpm_h2c_byp_$s] [get_bd_pins versal_cips_0/dma0_h2c_byp_out_$s]
+    }
+  } elseif {$cnfg(pcie_gen) eq 5} {
     # QDMA
     connect_bd_intf_net [get_bd_intf_ports pcie_clk] [get_bd_intf_pins versal_cips_0/gt_refclk1]
-    connect_bd_intf_net [get_bd_intf_ports pcie_gt] [get_bd_intf_pins versal_cips_0/PCIE1_GT] 
+    connect_bd_intf_net [get_bd_intf_ports pcie_gt] [get_bd_intf_pins versal_cips_0/PCIE1_GT]
 
     # Descriptor status
     connect_bd_intf_net [get_bd_intf_ports c2h_status] [get_bd_intf_pins versal_cips_0/dma1_axis_c2h_status]
@@ -545,11 +791,32 @@ proc cr_bd_design_static { parentCell } {
 
   # Debug Hub config
   connect_bd_intf_net [get_bd_intf_pins axi_noc_0/M03_AXI] [get_bd_intf_ports axi_debug_hub]
+
+  # VCK5000 only: BRAM datapath + physical DDR4 / sysclk for the integrated DDR MC.
+  if {$cnfg(fdev) eq "vck5000"} {
+    connect_bd_intf_net [get_bd_intf_pins axi_noc_0/M04_AXI] [get_bd_intf_pins bram_ctrl_0/S_AXI]
+    connect_bd_intf_net [get_bd_intf_ports c0_ddr4]      [get_bd_intf_pins axi_noc_0/CH0_DDR4_0]
+    connect_bd_intf_net [get_bd_intf_ports c0_sys_clk_0] [get_bd_intf_pins axi_noc_0/sys_clk0]
+  }
 ########################################################################################################
 # Create port connections
 ########################################################################################################
 
-  if {$cnfg(pcie_gen) eq 5} {
+  if {$cnfg(fdev) eq "vck5000"} {
+    # QDMA unused ready signals tied to 1 (h2c_byp_out.ready and c2h_byp_out.ready are driven
+    # by the shim, not tied -- c2h_byp_out is the C2H credit stream for the pairing loop).
+    connect_bd_net [get_bd_pins const_1/dout] [get_bd_pins versal_cips_0/dma0_st_rx_msg_tready]
+    # tm_dsc_sts is unused (H2C completion is taken from h2c_byp_out); accept its beats
+    connect_bd_net [get_bd_pins const_1/dout] [get_bd_pins versal_cips_0/dma0_tm_dsc_sts_rdy]
+    # CPM4 uses dma0_soft_resetn (no dma0_intrfc_resetn); tie inactive (high)
+    connect_bd_net [get_bd_pins const_1/dout] [get_bd_pins versal_cips_0/dma0_soft_resetn]
+    # Tie off unused CPM4 QDMA slave inputs (cache-bypass C2H, MM C2H, descriptor credit, mgmt).
+    # C2H uses the SIMPLE bypass port (st_sim, shim-driven); the cache port (st_csh) is unused.
+    connect_bd_net [get_bd_pins const_0/dout] [get_bd_pins versal_cips_0/dma0_c2h_byp_in_st_csh_valid]
+    connect_bd_net [get_bd_pins const_0/dout] [get_bd_pins versal_cips_0/dma0_c2h_byp_in_mm_valid]
+    connect_bd_net [get_bd_pins const_0/dout] [get_bd_pins versal_cips_0/dma0_dsc_crdt_in_valid]
+    connect_bd_net [get_bd_pins const_0/dout] [get_bd_pins versal_cips_0/dma0_mgmt_req_vld]
+  } elseif {$cnfg(pcie_gen) eq 5} {
     # QDMA unused ready signals are tied off to 1
     connect_bd_net [get_bd_pins const_1/dout] [get_bd_pins versal_cips_0/dma1_st_rx_msg_tready]
     connect_bd_net [get_bd_pins const_1/dout] [get_bd_pins versal_cips_0/dma1_tm_dsc_sts_rdy]
@@ -593,13 +860,26 @@ proc cr_bd_design_static { parentCell } {
   connect_bd_net [get_bd_pins versal_cips_0/noc_pmc_axi_axi0_clk] [get_bd_pins axi_noc_0/aclk4]
   
   # Main shell clock
-  connect_bd_net [get_bd_pins versal_cips_0/pl0_ref_clk] [get_bd_pins clk_wiz_0/clk_in1] 
+  connect_bd_net [get_bd_pins versal_cips_0/pl0_ref_clk] [get_bd_pins clk_wiz_0/clk_in1]
 
-  connect_bd_net [get_bd_pins clk_wiz_0/clk_out1] [get_bd_ports xclk] 
-  connect_bd_net [get_bd_pins clk_wiz_0/clk_out1] [get_bd_pins axi_noc_0/aclk3] 
-  connect_bd_net [get_bd_pins clk_wiz_0/clk_out1] [get_bd_pins smartconnect_0/aclk]
-  connect_bd_net [get_bd_pins clk_wiz_0/clk_out1] [get_bd_pins smartconnect_1/aclk]
-  if {$cnfg(pcie_gen) eq 5} {
+  # Shell clock source: on the V80 (CPM5) the clk_wiz output drives the QDMA interface clock
+  # (dma*_intrfc_clk) and the shell, so both share it. CPM4 has no dma0_intrfc_clk input --- its
+  # QDMA AXIS run on the CPM output pcie0_user_clk --- so the VCK5000 shell runs directly on
+  # pcie0_user_clk (keeping streams and shell synchronous, no extra CDC). clk_wiz is left driven
+  # but unused for vck5000.
+  if {$cnfg(fdev) eq "vck5000"} {
+    set shell_clk [get_bd_pins versal_cips_0/pcie0_user_clk]
+  } else {
+    set shell_clk [get_bd_pins clk_wiz_0/clk_out1]
+  }
+
+  connect_bd_net $shell_clk [get_bd_ports xclk]
+  connect_bd_net $shell_clk [get_bd_pins axi_noc_0/aclk3]
+  connect_bd_net $shell_clk [get_bd_pins smartconnect_0/aclk]
+  connect_bd_net $shell_clk [get_bd_pins smartconnect_1/aclk]
+  if {$cnfg(fdev) eq "vck5000"} {
+    # CPM4 QDMA has no dma0_intrfc_clk to drive
+  } elseif {$cnfg(pcie_gen) eq 5} {
     connect_bd_net [get_bd_pins clk_wiz_0/clk_out1] [get_bd_pins versal_cips_0/dma1_intrfc_clk]
   } elseif {$cnfg(pcie_gen) eq 4} {
     connect_bd_net [get_bd_pins clk_wiz_0/clk_out1] [get_bd_pins versal_cips_0/dma0_intrfc_clk]
@@ -610,9 +890,22 @@ proc cr_bd_design_static { parentCell } {
 
   # System reset
   connect_bd_net [get_bd_ports sresetn] [get_bd_pins proc_sys_reset_s/peripheral_aresetn]
-  connect_bd_net [get_bd_pins clk_wiz_0/clk_out1] [get_bd_pins proc_sys_reset_s/slowest_sync_clk]
+  connect_bd_net $shell_clk [get_bd_pins proc_sys_reset_s/slowest_sync_clk]
 
-  if {$cnfg(pcie_gen) eq 5} {
+  if {$cnfg(fdev) eq "vck5000"} {
+    # System reset from CPM4 QDMA AXI reset
+    connect_bd_net [get_bd_pins versal_cips_0/dma0_axi_aresetn] [get_bd_pins proc_sys_reset_s/ext_reset_in]
+    # SmartConnect reset
+    connect_bd_net [get_bd_pins versal_cips_0/dma0_axi_aresetn] [get_bd_pins smartconnect_0/aresetn]
+    connect_bd_net [get_bd_pins versal_cips_0/dma0_axi_aresetn] [get_bd_pins smartconnect_1/aresetn]
+    # BRAM controller runs in the shell clock domain, reset by the QDMA AXI reset
+    connect_bd_net $shell_clk [get_bd_pins bram_ctrl_0/s_axi_aclk]
+    connect_bd_net [get_bd_pins versal_cips_0/dma0_axi_aresetn] [get_bd_pins bram_ctrl_0/s_axi_aresetn]
+    # CPM4<->eQDMA shim: the C2H command FIFO (credit pairing) runs on the QDMA fabric clock
+    # (= shell clock, pcie0_user_clk), reset by the QDMA AXI reset
+    connect_bd_net $shell_clk [get_bd_pins cpm4_shim_0/aclk]
+    connect_bd_net [get_bd_pins versal_cips_0/dma0_axi_aresetn] [get_bd_pins cpm4_shim_0/aresetn]
+  } elseif {$cnfg(pcie_gen) eq 5} {
     # System reset
     connect_bd_net [get_bd_pins versal_cips_0/dma1_axi_aresetn] [get_bd_pins proc_sys_reset_s/ext_reset_in] 
     
@@ -634,10 +927,15 @@ proc cr_bd_design_static { parentCell } {
   # Shell reset
   connect_bd_net [get_bd_ports xresetn] [get_bd_pins proc_sys_reset_x/peripheral_aresetn]
   connect_bd_net [get_bd_ports eos_resetn] [get_bd_pins proc_sys_reset_x/ext_reset_in]
-  connect_bd_net [get_bd_pins proc_sys_reset_x/slowest_sync_clk] [get_bd_pins clk_wiz_0/clk_out1]
+  connect_bd_net [get_bd_pins proc_sys_reset_x/slowest_sync_clk] $shell_clk
 
-  # EOS
-  connect_bd_net [get_bd_pins versal_cips_0/eos] [get_bd_ports eos_pmc]
+  # EOS (PMC end-of-startup). If the CPM4 CIPS does not expose an 'eos' pin, tie the
+  # eos_pmc port low (PR-completion signalling is refined during board bring-up).
+  if {[llength [get_bd_pins -quiet versal_cips_0/eos]] > 0} {
+    connect_bd_net [get_bd_pins versal_cips_0/eos] [get_bd_ports eos_pmc]
+  } else {
+    connect_bd_net [get_bd_pins const_0/dout] [get_bd_ports eos_pmc]
+  }
 
 ########################################################################################################
 # Create address segments
@@ -654,7 +952,22 @@ proc cr_bd_design_static { parentCell } {
 
   # PMC_NOC_AXI_0 for configuring the Debug Hub IP
   assign_bd_address -offset 0x020240000000 -range 2M -target_address_space [get_bd_addr_spaces versal_cips_0/PMC_NOC_AXI_0] [get_bd_addr_segs axi_debug_hub/Reg] -force
-  
+
+  # VCK5000 only: map the integrated DDR (fixed-address DDR_LOW0/1 segments) and the BRAM
+  # into both CPM_PCIE_NOC address spaces. DDR segments carry a fixed base (no -offset); the
+  # BRAM is placed at 0x0203_0000_0000 (matching its M04_AXI aperture).
+  if {$cnfg(fdev) eq "vck5000"} {
+    # S00_AXI carries CPM_PCIE_NOC_0, S01_AXI carries CPM_PCIE_NOC_1.
+    foreach {sp si} {CPM_PCIE_NOC_0 S00_AXI CPM_PCIE_NOC_1 S01_AXI} {
+      # BRAM (512 KB)
+      catch { assign_bd_address -offset 0x020300000000 -range 512K -target_address_space [get_bd_addr_spaces versal_cips_0/$sp] [get_bd_addr_segs bram_ctrl_0/S_AXI/Mem0] -force }
+      # DDR (all C*_DDR_* channel segments visible on this NoC slave port)
+      foreach seg [get_bd_addr_segs -quiet axi_noc_0/$si/C*_DDR_*] {
+        catch { assign_bd_address -target_address_space [get_bd_addr_spaces versal_cips_0/$sp] $seg -force }
+      }
+    }
+  }
+
   # Restore current instance
   current_bd_instance $oldCurInst
 

--- a/hw/bd/versal/vck5000_ddr4_hier.reference.tcl
+++ b/hw/bd/versal/vck5000_ddr4_hier.reference.tcl
@@ -1,0 +1,4 @@
+# Reference: VCK5000 DDR4-over-NoC hierarchical cell (provided by user).
+# 4x DDR4 channels (c0..c3), 8GB each (16Gb x16, DDR4-3200), integrated DDRMC per channel
+# via axi_noc:1.0; fed by NoC INI links (S00_INI..S00_INI3 + distribution axi_noc_0).
+# To be adapted into hw/bd/versal/cr_ddr.tcl and integrated with Coyote's card-memory path.

--- a/hw/constraints/vck5000/dynamic/impl/empty.xdc
+++ b/hw/constraints/vck5000/dynamic/impl/empty.xdc
@@ -1,0 +1,4 @@
+# Placeholder file to make sure the folder dynamic/impl exists in git,
+# since it is used when synthesizing Coyote. In Stage 2 (Versal DDR) and when
+# dynamic services (e.g., networking) are added to the VCK5000, this file will be
+# replaced with actual constraints (e.g., DDR4 pinout from the board file).

--- a/hw/constraints/vck5000/shell/impl/empty.xdc
+++ b/hw/constraints/vck5000/shell/impl/empty.xdc
@@ -1,0 +1,3 @@
+# Placeholder file to make sure the folder shell/impl exists in git,
+# since it is used when synthesizing Coyote. Additional constraints
+# to be added in the future, as new features for the VCK5000 are added.

--- a/hw/constraints/vck5000/shell/synth/empty.xdc
+++ b/hw/constraints/vck5000/shell/synth/empty.xdc
@@ -1,0 +1,3 @@
+# Placeholder file to make sure the folder shell/synth exists in git,
+# since it is used when synthesizing Coyote. Additional constraints
+# to be added in the future, as new features for the VCK5000 are added.

--- a/hw/constraints/vck5000/static/impl/vck5000_static_base.xdc
+++ b/hw/constraints/vck5000/static/impl/vck5000_static_base.xdc
@@ -1,0 +1,27 @@
+# Power constraint (VCK5000 is a 225 W card; budget for the power DRC estimate)
+set_operating_conditions -design_power_budget 180
+
+# Compress bitstream
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design];
+
+# =====================================================================================
+# PCIe reference clock (VCK5000) --- matched to the known-good VCK5000 CPM QDMA design.
+#
+# The board delivers the 100 MHz host PCIe ref on pcie_refclk_2 (R36/R37); the CPM4
+# otherwise defaults it to pcie_refclk_0 (AB34/AB35) which is unconnected -> CPM PLL never
+# locks -> link never trains. So the refclk pin MUST be pinned explicitly.
+#
+# GT lanes: NOT pinned here. The CPM PCIe (X16, CPM_PCIE0) auto-places its 16 GT lanes onto
+# the board's PCIe pins via the silicon-fixed CPM->GTY mapping (verified: the x8 build placed
+# lanes on the exact board pins with no lane XDC). Explicit lane LOCs are avoided because the
+# VCK5000 board file lists lane 15 rx AND tx both on B40/B39 (a board-file duplication) which
+# would collide if pinned; the silicon mapping resolves lane 15 correctly.
+#
+# No PCIE40_X0Y1 site LOC: on Vivado 2023.2 / versal_cips 3.4 the CPM is a monolithic hardened
+# block (no user-placeable pcie_4_0_e5_inst cell); the CIPS auto-places the PCIe GTs correctly.
+# =====================================================================================
+
+# PCIe reference clock (100 MHz) --- pcie_refclk_2
+set_property PACKAGE_PIN R37 [get_ports {pcie_clk_clk_n[0]}]
+set_property PACKAGE_PIN R36 [get_ports {pcie_clk_clk_p[0]}]
+create_clock -period 10.000 -name pcie_ref_clk [get_ports {pcie_clk_clk_p[0]}];

--- a/hw/constraints/vck5000/static/synth/vck5000_static_synth.xdc
+++ b/hw/constraints/vck5000/static/synth/vck5000_static_synth.xdc
@@ -1,0 +1,5 @@
+# PCIe reference clock (100 MHz), synthesis-stage timing definition.
+# NOTE: the physical refclk + GT-lane PACKAGE_PINs are set in static/impl/vck5000_static_base.xdc.
+# The CPM4 auto-default put the refclk on the wrong board pin (pcie_refclk_0); the VCK5000 board
+# actually routes the host PCIe refclk to pcie_refclk_2 (R36/R37), so it must be pinned explicitly.
+create_clock -period 10.000 [get_ports pcie_clk_clk_p];

--- a/hw/hdl/static/cpm4_qdma_shim.v
+++ b/hw/hdl/static/cpm4_qdma_shim.v
@@ -1,0 +1,359 @@
+// CPM4 <-> eQDMA shim for the VCK5000 (Versal VC1902).
+//
+// Keeps design_static's boundary IDENTICAL to the V80 (CPM5/eQDMA) by converting, entirely
+// inside design_static, between the CPM4 (plain QDMA) versal_cips pins and the eQDMA-style
+// boundary interfaces the rest of Coyote (static_top, qdma_rd/wr wrappers) consumes.
+//
+// Boundary interfaces presented (full V80 member sets, matching static_top):
+//   m_axis_h2c (display_eqdma, Master)  s_axis_c2h (display_eqdma, Slave)
+//   h2c_status (eqdma_qsts, Master)     c2h_status (qdma_c2h_status, Master)
+//   dsc_bypass_c2h (qdma_dsc_byp, Slave) dsc_pr (qdma_dsc_byp MM, Slave)
+// (dsc_bypass_h2c is connected directly to CPM4 in cr_pci.tcl; its members all exist on CPM4.)
+//
+// CPM4 gaps bridged: tcrc/ecc (m/s data), pfch_tag (c2h cmd), no_dma (pr), error/last/status_cmp
+// (c2h status) do not exist on CPM4 -> defaulted here; qid is 12b on the boundary vs 11b on CPM4
+// streams -> width-adapted. Build/timing-oriented; functional semantics refined on the board.
+module cpm4_qdma_shim (
+  // ===== boundary: H2C data (eQDMA m_axis_h2c, Master out) =====
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:m_axis_h2c_rtl:1.0 m_axis_h2c tdata"     *) output wire [511:0] m_axis_h2c_tdata,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:m_axis_h2c_rtl:1.0 m_axis_h2c tcrc"      *) output wire [31:0]  m_axis_h2c_tcrc,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:m_axis_h2c_rtl:1.0 m_axis_h2c tvalid"    *) output wire         m_axis_h2c_tvalid,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:m_axis_h2c_rtl:1.0 m_axis_h2c tlast"     *) output wire         m_axis_h2c_tlast,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:m_axis_h2c_rtl:1.0 m_axis_h2c tready"    *) input  wire         m_axis_h2c_tready,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:m_axis_h2c_rtl:1.0 m_axis_h2c qid"       *) output wire [11:0]  m_axis_h2c_qid,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:m_axis_h2c_rtl:1.0 m_axis_h2c port_id"   *) output wire [2:0]   m_axis_h2c_port_id,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:m_axis_h2c_rtl:1.0 m_axis_h2c err"       *) output wire         m_axis_h2c_err,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:m_axis_h2c_rtl:1.0 m_axis_h2c mdata"     *) output wire [31:0]  m_axis_h2c_mdata,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:m_axis_h2c_rtl:1.0 m_axis_h2c mty"       *) output wire [5:0]   m_axis_h2c_mty,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:m_axis_h2c_rtl:1.0 m_axis_h2c zero_byte" *) output wire         m_axis_h2c_zero_byte,
+
+  // ===== boundary: C2H data (eQDMA s_axis_c2h, Slave in) =====
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:s_axis_c2h_rtl:1.0 s_axis_c2h tdata"         *) input  wire [511:0] s_axis_c2h_tdata,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:s_axis_c2h_rtl:1.0 s_axis_c2h tvalid"        *) input  wire         s_axis_c2h_tvalid,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:s_axis_c2h_rtl:1.0 s_axis_c2h tlast"         *) input  wire         s_axis_c2h_tlast,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:s_axis_c2h_rtl:1.0 s_axis_c2h tready"        *) output wire         s_axis_c2h_tready,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:s_axis_c2h_rtl:1.0 s_axis_c2h tcrc"          *) input  wire [31:0]  s_axis_c2h_tcrc,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:s_axis_c2h_rtl:1.0 s_axis_c2h ecc"           *) input  wire [6:0]   s_axis_c2h_ecc,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:s_axis_c2h_rtl:1.0 s_axis_c2h mty"           *) input  wire [5:0]   s_axis_c2h_mty,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:s_axis_c2h_rtl:1.0 s_axis_c2h ctrl_marker"   *) input  wire         s_axis_c2h_ctrl_marker,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:s_axis_c2h_rtl:1.0 s_axis_c2h ctrl_port_id"  *) input  wire [2:0]   s_axis_c2h_ctrl_port_id,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:s_axis_c2h_rtl:1.0 s_axis_c2h ctrl_len"      *) input  wire [15:0]  s_axis_c2h_ctrl_len,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:s_axis_c2h_rtl:1.0 s_axis_c2h ctrl_qid"      *) input  wire [11:0]  s_axis_c2h_ctrl_qid,
+  (* X_INTERFACE_INFO = "xilinx.com:display_eqdma:s_axis_c2h_rtl:1.0 s_axis_c2h ctrl_has_cmpt" *) input  wire         s_axis_c2h_ctrl_has_cmpt,
+
+  // ===== boundary: H2C status (eqdma_qsts, Master out) =====
+  (* X_INTERFACE_INFO = "xilinx.com:interface:eqdma_qsts_rtl:1.0 h2c_status vld"     *) output wire         h2c_status_vld,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:eqdma_qsts_rtl:1.0 h2c_status rdy"     *) input  wire         h2c_status_rdy,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:eqdma_qsts_rtl:1.0 h2c_status op"      *) output wire [7:0]   h2c_status_op,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:eqdma_qsts_rtl:1.0 h2c_status data"    *) output wire [63:0]  h2c_status_data,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:eqdma_qsts_rtl:1.0 h2c_status qid"     *) output wire [11:0]  h2c_status_qid,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:eqdma_qsts_rtl:1.0 h2c_status port_id" *) output wire [2:0]   h2c_status_port_id,
+
+  // ===== boundary: C2H status (qdma_c2h_status, Master out) =====
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_c2h_status_rtl:1.0 c2h_status drop"       *) output wire         c2h_status_drop,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_c2h_status_rtl:1.0 c2h_status error"      *) output wire         c2h_status_error,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_c2h_status_rtl:1.0 c2h_status last"       *) output wire         c2h_status_last,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_c2h_status_rtl:1.0 c2h_status qid"        *) output wire [11:0]  c2h_status_qid,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_c2h_status_rtl:1.0 c2h_status status_cmp" *) output wire         c2h_status_status_cmp,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_c2h_status_rtl:1.0 c2h_status valid"      *) output wire         c2h_status_valid,
+
+  // ===== boundary: C2H command / descriptor bypass (qdma_dsc_byp, Slave in) =====
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_bypass_c2h addr"     *) input  wire [63:0]  dsc_bypass_c2h_addr,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_bypass_c2h error"    *) input  wire         dsc_bypass_c2h_error,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_bypass_c2h func"     *) input  wire [11:0]  dsc_bypass_c2h_func,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_bypass_c2h pfch_tag" *) input  wire [6:0]   dsc_bypass_c2h_pfch_tag,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_bypass_c2h port_id"  *) input  wire [2:0]   dsc_bypass_c2h_port_id,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_bypass_c2h qid"      *) input  wire [11:0]  dsc_bypass_c2h_qid,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_bypass_c2h ready"    *) output wire         dsc_bypass_c2h_ready,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_bypass_c2h valid"    *) input  wire         dsc_bypass_c2h_valid,
+
+  // ===== boundary: PR MM descriptor (qdma_dsc_byp MM, Slave in) =====
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_pr radr"     *) input  wire [63:0]  dsc_pr_radr,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_pr wadr"     *) input  wire [63:0]  dsc_pr_wadr,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_pr cidx"     *) input  wire [15:0]  dsc_pr_cidx,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_pr error"    *) input  wire         dsc_pr_error,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_pr func"     *) input  wire [11:0]  dsc_pr_func,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_pr len"      *) input  wire [15:0]  dsc_pr_len,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_pr mrkr_req" *) input  wire         dsc_pr_mrkr_req,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_pr no_dma"   *) input  wire         dsc_pr_no_dma,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_pr port_id"  *) input  wire [2:0]   dsc_pr_port_id,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_pr qid"      *) input  wire [11:0]  dsc_pr_qid,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_pr ready"    *) output wire         dsc_pr_ready,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_pr sdi"      *) input  wire         dsc_pr_sdi,
+  (* X_INTERFACE_INFO = "xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dsc_pr valid"    *) input  wire         dsc_pr_valid,
+
+  // ================= CPM4 versal_cips side (scalar) =================
+  // H2C data (from CPM4, qid 11b)
+  input  wire [511:0] cpm_h2c_tdata,
+  input  wire         cpm_h2c_tvalid,
+  input  wire         cpm_h2c_tlast,
+  output wire         cpm_h2c_tready,
+  input  wire [10:0]  cpm_h2c_qid,
+  input  wire [2:0]   cpm_h2c_port_id,
+  input  wire         cpm_h2c_err,
+  input  wire [31:0]  cpm_h2c_mdata,
+  input  wire [5:0]   cpm_h2c_mty,
+  input  wire         cpm_h2c_zero_byte,
+  // C2H data (to CPM4, qid 11b)
+  output wire [511:0] cpm_c2h_tdata,
+  output wire         cpm_c2h_tvalid,
+  output wire         cpm_c2h_tlast,
+  input  wire         cpm_c2h_tready,
+  output wire [5:0]   cpm_c2h_mty,
+  output wire [63:0]  cpm_c2h_dpar,
+  output wire         cpm_c2h_ctrl_marker,
+  output wire [2:0]   cpm_c2h_ctrl_port_id,
+  output wire [15:0]  cpm_c2h_ctrl_len,
+  output wire [10:0]  cpm_c2h_ctrl_qid,
+  output wire         cpm_c2h_ctrl_dis_cmpt,
+  // C2H completion stream (to CPM4 dma0_s_axis_c2h_cmpt): one 8B standard-format CMPT record
+  // per data packet (the silicon-validated completion mechanism; consumed by the driver's
+  // host CMPT ring). Record format per the CED c2h_stub_std_cmp_ent_t:
+  // bit0 data_format=0 (standard), bits[11:1] qid, rest user data.
+  output wire [127:0] cpm_c2h_cmpt_data,
+  output wire [15:0]  cpm_c2h_cmpt_dpar,
+  output wire [1:0]   cpm_c2h_cmpt_size,
+  output wire         cpm_c2h_cmpt_tlast,
+  output wire         cpm_c2h_cmpt_tvalid,
+  input  wire         cpm_c2h_cmpt_tready,
+  // C2H command / descriptor bypass IN (to CPM4 dma0_c2h_byp_in_st_sim -- SIMPLE bypass).
+  // CPM4's byp_in carries no pfch_tag; each byp_in beat must be paired 1:1 with a c2h_byp_out
+  // credit (a ring descriptor the engine fetched) -- that pairing recycles the prefetch slot.
+  // The address presented is the FPGA-chosen host address (overriding the ring descriptor's),
+  // which is proven to DMA correctly on HW.
+  output wire [63:0]  cpm_c2h_byp_addr,
+  output wire         cpm_c2h_byp_error,
+  output wire [11:0]  cpm_c2h_byp_func,
+  output wire [2:0]   cpm_c2h_byp_port_id,
+  output wire [11:0]  cpm_c2h_byp_qid,
+  input  wire         cpm_c2h_byp_ready,
+  output wire         cpm_c2h_byp_valid,
+  // C2H descriptor bypass OUT (from CPM4 dma0_c2h_byp_out): the credit stream. Each valid ST
+  // non-marker beat is one fetched ring descriptor; its content is discarded (address is
+  // overridden by the FPGA's). Marker-response / MM beats are dropped without pairing.
+  input  wire         cpm_c2h_byp_out_valid,
+  input  wire         cpm_c2h_byp_out_mrkr_rsp,
+  input  wire         cpm_c2h_byp_out_st_mm,
+  input  wire [10:0]  cpm_c2h_byp_out_qid,
+  input  wire         cpm_c2h_byp_out_error,
+  output wire         cpm_c2h_byp_out_ready,
+  // PR MM descriptor (to CPM4) --- no no_dma on CPM4
+  output wire [63:0]  cpm_pr_radr,
+  output wire [63:0]  cpm_pr_wadr,
+  output wire [15:0]  cpm_pr_cidx,
+  output wire         cpm_pr_error,
+  output wire [11:0]  cpm_pr_func,
+  output wire [15:0]  cpm_pr_len,
+  output wire         cpm_pr_mrkr_req,
+  output wire [2:0]   cpm_pr_port_id,
+  output wire [11:0]  cpm_pr_qid,
+  input  wire         cpm_pr_ready,
+  output wire         cpm_pr_sdi,
+  output wire         cpm_pr_valid,
+  // C2H status (from CPM4) --- only drop/qid/valid on CPM4
+  input  wire         cpm_c2h_sts_drop,
+  input  wire [11:0]  cpm_c2h_sts_qid,
+  input  wire         cpm_c2h_sts_valid,
+  // H2C descriptor-bypass output (from CPM4) --- carries the per-descriptor marker response
+  input  wire         cpm_h2c_byp_valid,
+  input  wire         cpm_h2c_byp_mrkr_rsp,
+  input  wire         cpm_h2c_byp_error,
+  input  wire [11:0]  cpm_h2c_byp_qid,
+  input  wire [2:0]   cpm_h2c_byp_port_id,
+  output wire         cpm_h2c_byp_ready,
+  // Clock/reset (QDMA fabric clock domain) -- for the C2H command FIFO
+  input  wire         aclk,
+  input  wire         aresetn
+);
+
+  // ---- H2C data: CPM4 -> boundary (qid zero-extended 11->12; tcrc has no CPM4 source) ----
+  assign m_axis_h2c_tdata     = cpm_h2c_tdata;
+  assign m_axis_h2c_tvalid    = cpm_h2c_tvalid;
+  assign m_axis_h2c_tlast     = cpm_h2c_tlast;
+  assign cpm_h2c_tready       = m_axis_h2c_tready;
+  assign m_axis_h2c_qid       = {1'b0, cpm_h2c_qid};
+  assign m_axis_h2c_port_id   = cpm_h2c_port_id;
+  assign m_axis_h2c_err       = cpm_h2c_err;
+  assign m_axis_h2c_mdata     = cpm_h2c_mdata;
+  assign m_axis_h2c_mty       = cpm_h2c_mty;
+  assign m_axis_h2c_zero_byte = cpm_h2c_zero_byte;
+  assign m_axis_h2c_tcrc      = 32'b0;
+
+  // ---- C2H data: boundary -> CPM4 (qid truncated 12->11; tcrc/ecc dropped) ----
+  // CPM4 checks per-byte ODD parity on the C2H write payload (dpar; ENG_WPL_DATA_PAR_ERR fires
+  // otherwise and the engine jams after the first descriptor match -- verified on HW). eQDMA
+  // uses tcrc/ecc instead, so the V80 path never needed this. Parity per the CED reference
+  // (ST_c2h.sv): dpar[i] = ~(^data[8i+:8]).
+  assign cpm_c2h_tdata         = s_axis_c2h_tdata;
+  assign cpm_c2h_tvalid        = s_axis_c2h_tvalid;
+  assign cpm_c2h_tlast         = s_axis_c2h_tlast;
+  assign s_axis_c2h_tready     = cpm_c2h_tready;
+  assign cpm_c2h_mty           = s_axis_c2h_mty;
+  genvar gi;
+  generate
+    for (gi = 0; gi < 64; gi = gi + 1) begin : g_c2h_dpar
+      assign cpm_c2h_dpar[gi] = ~(^s_axis_c2h_tdata[gi*8 +: 8]);
+    end
+  endgenerate
+  // No markers on data packets (ctrl_marker=1 turns a data packet into a flush token --
+  // HW-verified dead end). Completion is signaled via CMPT records instead (below), the
+  // mechanism validated on this silicon by the mm_st mini design (qdma_stm_c2h_stub + CMPT).
+  assign cpm_c2h_ctrl_marker   = 1'b0;
+  assign cpm_c2h_ctrl_port_id  = s_axis_c2h_ctrl_port_id;
+  assign cpm_c2h_ctrl_len      = s_axis_c2h_ctrl_len;
+  assign cpm_c2h_ctrl_qid      = s_axis_c2h_ctrl_qid[10:0];
+  // Completions ENABLED for every packet (dis_cmpt=0): the CPM4 C2H engine's validated
+  // operating mode sends one CMPT record per packet (consumed host-side by the driver's CMPT
+  // ring). The CMPT stream is generated below.
+  assign cpm_c2h_ctrl_dis_cmpt = 1'b0;
+
+  // ---- C2H simple-bypass credit pairing with FPGA-address override (CPM4) ----
+  // HW-verified mechanism: each C2H packet needs a descriptor credit. The one-shot credit from
+  // the 0x1408 tag arming let exactly ONE packet complete end-to-end (64B landed at the
+  // FPGA-chosen address); sustained flow requires recycling the prefetch slot by consuming each
+  // c2h_byp_out beat (a ring descriptor the engine fetched on data arrival) and returning a
+  // descriptor on byp_in_st_sim. We pair each of Coyote's fabric commands (dsc_bypass_c2h,
+  // FPGA-chosen host address) 1:1 with a credit -- the ring descriptor's content is discarded.
+  // Ref: Versal CPM Gen4x8 QDMA EP CED, dsc_byp_c2h.sv.
+  //
+  // Ordering: qdma_wr_wrapper streams a packet's DATA only after its command is accepted, while
+  // the engine fetches the ring descriptor (-> credit) only after the packet data arrives.
+  // Gating command-accept on the credit would deadlock, so commands are accepted immediately
+  // into a small FIFO; only the byp_in beat is gated on the credit. The wrapper is one-packet-
+  // at-a-time and the engine processes packets in order, so credits arrive in command order.
+  localparam C2H_CF_AW = 4;  // command FIFO depth 16
+  reg [63:0] cf_addr    [0:(1<<C2H_CF_AW)-1];
+  reg [11:0] cf_qid     [0:(1<<C2H_CF_AW)-1];
+  reg [11:0] cf_func    [0:(1<<C2H_CF_AW)-1];
+  reg [2:0]  cf_port_id [0:(1<<C2H_CF_AW)-1];
+  reg        cf_error   [0:(1<<C2H_CF_AW)-1];
+  reg [C2H_CF_AW:0] cf_wr, cf_rd;
+  wire cf_empty = (cf_wr == cf_rd);
+  wire cf_full  = (cf_wr[C2H_CF_AW-1:0] == cf_rd[C2H_CF_AW-1:0]) && (cf_wr[C2H_CF_AW] != cf_rd[C2H_CF_AW]);
+
+  assign dsc_bypass_c2h_ready = ~cf_full;                          // accept commands immediately
+  wire cf_push = dsc_bypass_c2h_valid & ~cf_full;
+
+  // Outstanding-limit semaphore (HW-derived): the armed prefetch slot holds ONE in-flight
+  // descriptor. A byp_in beat submitted while the slot is busy is silently lost (verified:
+  // ungated byp_in completed exactly packet 1; the rest starved). Fire byp_in only when no
+  // descriptor is outstanding; the slot frees on the axis_c2h_status pulse (count drops too,
+  // so a dropped packet cannot leak the semaphore).
+  reg [3:0] c2h_outst;
+  // Slot frees when the packet's CMPT record is accepted by the engine (per-packet, ordered
+  // behind the data DMA on PCIe -- the validated completion event on this silicon)
+  wire c2h_cmpt_fire;
+  wire c2h_sts_pulse = c2h_cmpt_fire;
+  wire c2h_byp_fire  = ~cf_empty & (c2h_outst == 4'd0) & cpm_c2h_byp_ready;
+
+  always @(posedge aclk) begin
+    if (!aresetn) begin
+      cf_wr <= {(C2H_CF_AW+1){1'b0}};
+      cf_rd <= {(C2H_CF_AW+1){1'b0}};
+      c2h_outst <= 4'd0;
+    end else begin
+      if (cf_push) begin
+        cf_addr   [cf_wr[C2H_CF_AW-1:0]] <= dsc_bypass_c2h_addr;
+        cf_qid    [cf_wr[C2H_CF_AW-1:0]] <= dsc_bypass_c2h_qid;
+        cf_func   [cf_wr[C2H_CF_AW-1:0]] <= dsc_bypass_c2h_func;
+        cf_port_id[cf_wr[C2H_CF_AW-1:0]] <= dsc_bypass_c2h_port_id;
+        cf_error  [cf_wr[C2H_CF_AW-1:0]] <= dsc_bypass_c2h_error;
+        cf_wr <= cf_wr + 1'b1;
+      end
+      if (c2h_byp_fire) begin
+        cf_rd <= cf_rd + 1'b1;
+      end
+      case ({c2h_byp_fire, c2h_sts_pulse})
+        2'b10:   c2h_outst <= c2h_outst + 1'b1;
+        2'b01:   c2h_outst <= (c2h_outst != 4'd0) ? c2h_outst - 1'b1 : 4'd0;
+        default: c2h_outst <= c2h_outst;   // both or neither -> net zero
+      endcase
+    end
+  end
+
+  assign cpm_c2h_byp_addr    = cf_addr   [cf_rd[C2H_CF_AW-1:0]];   // FPGA-chosen host address
+  assign cpm_c2h_byp_qid     = cf_qid    [cf_rd[C2H_CF_AW-1:0]];
+  assign cpm_c2h_byp_func    = cf_func   [cf_rd[C2H_CF_AW-1:0]];
+  assign cpm_c2h_byp_port_id = cf_port_id[cf_rd[C2H_CF_AW-1:0]];
+  assign cpm_c2h_byp_error   = cf_error  [cf_rd[C2H_CF_AW-1:0]];
+  assign cpm_c2h_byp_valid   = ~cf_empty & (c2h_outst == 4'd0);    // one outstanding at a time
+  assign cpm_c2h_byp_out_ready = 1'b1;                             // byp_out unused in this mode; discard
+
+  // ---- PR MM descriptor: boundary -> CPM4 (no_dma dropped) ----
+  assign cpm_pr_radr     = dsc_pr_radr;
+  assign cpm_pr_wadr     = dsc_pr_wadr;
+  assign cpm_pr_cidx     = dsc_pr_cidx;
+  assign cpm_pr_error    = dsc_pr_error;
+  assign cpm_pr_func     = dsc_pr_func;
+  assign cpm_pr_len      = dsc_pr_len;
+  assign cpm_pr_mrkr_req = dsc_pr_mrkr_req;
+  assign cpm_pr_port_id  = dsc_pr_port_id;
+  assign cpm_pr_qid      = dsc_pr_qid;
+  assign cpm_pr_sdi      = dsc_pr_sdi;
+  assign cpm_pr_valid    = dsc_pr_valid;
+  assign dsc_pr_ready    = cpm_pr_ready;
+
+  // ---- C2H completion: one CMPT record per packet + synthesized status (CPM4) ----
+  // CPM4's axis_c2h_status port does NOT pulse in bypass mode and ST markers kill the data
+  // path (both HW-verified). The silicon-validated completion mechanism (mm_st mini design,
+  // qdma_stm_c2h_stub + standard qdma-pf driver) is a per-packet CMPT record. The shim
+  // generates an 8B standard CMPT after each packet's last data beat; its ACCEPTANCE by the
+  // engine (ordered behind the data DMA) is the per-packet completion event driving both the
+  // boundary c2h_status pulse (qdma_wr_wrapper's done) and the descriptor-slot semaphore.
+  // The record content only needs qid + data_format for the host ring; the driver ignores it.
+  reg        cmpt_pend;          // a packet finished data; its CMPT is waiting to be sent
+  reg [10:0] cmpt_qid;           // qid of that packet (from ctrl_qid, stable through the packet)
+  wire c2h_pkt_last = cpm_c2h_tvalid & cpm_c2h_tready & cpm_c2h_tlast;
+  assign c2h_cmpt_fire = cmpt_pend & cpm_c2h_cmpt_tready;
+
+  always @(posedge aclk) begin
+    if (!aresetn) begin
+      cmpt_pend <= 1'b0;
+      cmpt_qid  <= 11'd0;
+    end else begin
+      if (c2h_pkt_last) begin
+        cmpt_pend <= 1'b1;                       // one outstanding packet at a time (semaphore)
+        cmpt_qid  <= s_axis_c2h_ctrl_qid[10:0];
+      end else if (c2h_cmpt_fire) begin
+        cmpt_pend <= 1'b0;
+      end
+    end
+  end
+
+  // 8B standard-format CMPT: bit0 data_format=0, bits[11:1] qid, upper bits unused (zeros).
+  wire [127:0] cmpt_rec = {116'b0, cmpt_qid, 1'b0};
+  assign cpm_c2h_cmpt_data   = cmpt_rec;
+  assign cpm_c2h_cmpt_size   = 2'b00;            // 8B record
+  assign cpm_c2h_cmpt_tlast  = 1'b1;             // single-beat record
+  assign cpm_c2h_cmpt_tvalid = cmpt_pend;
+  // Odd parity per 32-bit word across the beat (unused upper words are zero -> parity 1)
+  genvar gp;
+  generate
+    for (gp = 0; gp < 4; gp = gp + 1) begin : g_cmpt_dpar
+      assign cpm_c2h_cmpt_dpar[gp] = ~(^cmpt_rec[gp*32 +: 32]);
+    end
+  endgenerate
+  assign cpm_c2h_cmpt_dpar[15:4] = 12'hFFF;
+
+  // Boundary status pulse on CMPT acceptance
+  assign c2h_status_valid      = c2h_cmpt_fire;
+  assign c2h_status_qid        = {1'b0, cmpt_qid};
+  assign c2h_status_drop       = 1'b0;
+  assign c2h_status_error      = 1'b0;
+  assign c2h_status_last       = 1'b0;   // unused by qdma_wr_wrapper
+  assign c2h_status_status_cmp = 1'b0;   // unused by qdma_wr_wrapper
+
+  // ---- H2C completion: CPM4 dma0_h2c_byp_out (marker response) -> boundary eqdma_qsts ----
+  // Coyote's qdma_rd_wrapper flags H2C done on (op==8'h1 && !data[16]), citing PG302 v5.0
+  // Table 77 (op=0x1 => H2C-ST) and Table 79 (data[16] => error). In CPM4 QDMA ST
+  // descriptor-bypass, every descriptor is submitted with mrkr_req=1 (SOP=EOP), so the H2C
+  // engine echoes a marker response on dma0_h2c_byp_out (mrkr_rsp) per completed descriptor.
+  // That echo is the fabric-facing completion; map it into the eQDMA qsts fields:
+  assign h2c_status_vld     = cpm_h2c_byp_valid & cpm_h2c_byp_mrkr_rsp;
+  assign cpm_h2c_byp_ready  = 1'b1;                              // Coyote ties qsts rdy high; always accept
+  assign h2c_status_op      = 8'h1;                              // H2C-ST (PG302 Table 77)
+  assign h2c_status_data    = {47'b0, cpm_h2c_byp_error, 16'b0}; // data[16] = error (PG302 Table 79)
+  assign h2c_status_qid     = cpm_h2c_byp_qid;
+  assign h2c_status_port_id = cpm_h2c_byp_port_id;
+
+endmodule

--- a/hw/templates/common/cyt_top_tmplt.txt
+++ b/hw/templates/common/cyt_top_tmplt.txt
@@ -249,6 +249,47 @@ module cyt_top (
     (* io_buffer_type = "none" *) inout  wire[17:0]           c3_ddr4_dqs_t,
     (* io_buffer_type = "none" *) inout  wire[17:0]           c3_ddr4_dqs_c,
     {% endif %}
+    {% if cnfg.en_dcard and cnfg.fpga_arch == 'versal' %}
+    // VCK5000 DDR4 (over the NoC): 16Gb x16, 64-bit data (no ECC), 200 MHz sysclk
+    {% for m in range(0, cnfg.n_ddr_chan) %}
+    (* io_buffer_type = "none" *) output wire                 c{{ m }}_ddr4_act_n,
+    (* io_buffer_type = "none" *) output wire[16:0]           c{{ m }}_ddr4_adr,
+    (* io_buffer_type = "none" *) output wire[1:0]            c{{ m }}_ddr4_ba,
+    (* io_buffer_type = "none" *) output wire[0:0]            c{{ m }}_ddr4_bg,
+    (* io_buffer_type = "none" *) output wire[0:0]            c{{ m }}_ddr4_ck_c,
+    (* io_buffer_type = "none" *) output wire[0:0]            c{{ m }}_ddr4_ck_t,
+    (* io_buffer_type = "none" *) output wire[0:0]            c{{ m }}_ddr4_cke,
+    (* io_buffer_type = "none" *) output wire[0:0]            c{{ m }}_ddr4_cs_n,
+    (* io_buffer_type = "none" *) inout  wire[7:0]            c{{ m }}_ddr4_dm_n,
+    (* io_buffer_type = "none" *) inout  wire[63:0]           c{{ m }}_ddr4_dq,
+    (* io_buffer_type = "none" *) inout  wire[7:0]            c{{ m }}_ddr4_dqs_c,
+    (* io_buffer_type = "none" *) inout  wire[7:0]            c{{ m }}_ddr4_dqs_t,
+    (* io_buffer_type = "none" *) output wire[0:0]            c{{ m }}_ddr4_odt,
+    (* io_buffer_type = "none" *) output wire                 c{{ m }}_ddr4_reset_n,
+    (* io_buffer_type = "none" *) input  wire                 c{{ m }}_sys_clk_p,
+    (* io_buffer_type = "none" *) input  wire                 c{{ m }}_sys_clk_n,
+    {% endfor %}
+    {% endif %}
+    {% if cnfg.fdev == 'vck5000' and not cnfg.en_dcard %}
+    // VCK5000 STATIC DDR4 (integrated MC in the STATIC layer, backs the CPM4 QDMA NoC path):
+    // 16Gb x16, 64-bit data (no ECC), 200 MHz sysclk. Owned by the static when the shell has no DDR.
+    (* io_buffer_type = "none" *) output wire                 c0_ddr4_act_n,
+    (* io_buffer_type = "none" *) output wire[16:0]           c0_ddr4_adr,
+    (* io_buffer_type = "none" *) output wire[1:0]            c0_ddr4_ba,
+    (* io_buffer_type = "none" *) output wire[0:0]            c0_ddr4_bg,
+    (* io_buffer_type = "none" *) output wire[0:0]            c0_ddr4_ck_c,
+    (* io_buffer_type = "none" *) output wire[0:0]            c0_ddr4_ck_t,
+    (* io_buffer_type = "none" *) output wire[0:0]            c0_ddr4_cke,
+    (* io_buffer_type = "none" *) output wire[0:0]            c0_ddr4_cs_n,
+    (* io_buffer_type = "none" *) inout  wire[7:0]            c0_ddr4_dm_n,
+    (* io_buffer_type = "none" *) inout  wire[63:0]           c0_ddr4_dq,
+    (* io_buffer_type = "none" *) inout  wire[7:0]            c0_ddr4_dqs_c,
+    (* io_buffer_type = "none" *) inout  wire[7:0]            c0_ddr4_dqs_t,
+    (* io_buffer_type = "none" *) output wire[0:0]            c0_ddr4_odt,
+    (* io_buffer_type = "none" *) output wire                 c0_ddr4_reset_n,
+    (* io_buffer_type = "none" *) input  wire                 c0_sys_clk_p,
+    (* io_buffer_type = "none" *) input  wire                 c0_sys_clk_n,
+    {% endif %}
     {% if cnfg.fdev == 'u280' or cnfg.fdev == 'u50d' or cnfg.fdev == 'u55c' %}
     // HBM
     (* io_buffer_type = "none" *) input  wire[0:0]            hbm_clk_clk_n,
@@ -404,6 +445,26 @@ module cyt_top (
 
         // Writeback
         .s_wback(wback_sh2st),
+
+    {% if cnfg.fdev == 'vck5000' and not cnfg.en_dcard %}
+        // STATIC DDR4 + 200 MHz system clock (integrated MC in design_static)
+        .c0_ddr4_act_n(c0_ddr4_act_n),
+        .c0_ddr4_adr(c0_ddr4_adr),
+        .c0_ddr4_ba(c0_ddr4_ba),
+        .c0_ddr4_bg(c0_ddr4_bg),
+        .c0_ddr4_ck_c(c0_ddr4_ck_c),
+        .c0_ddr4_ck_t(c0_ddr4_ck_t),
+        .c0_ddr4_cke(c0_ddr4_cke),
+        .c0_ddr4_cs_n(c0_ddr4_cs_n),
+        .c0_ddr4_dm_n(c0_ddr4_dm_n),
+        .c0_ddr4_dq(c0_ddr4_dq),
+        .c0_ddr4_dqs_c(c0_ddr4_dqs_c),
+        .c0_ddr4_dqs_t(c0_ddr4_dqs_t),
+        .c0_ddr4_odt(c0_ddr4_odt),
+        .c0_ddr4_reset_n(c0_ddr4_reset_n),
+        .c0_sys_clk_0_clk_p(c0_sys_clk_p),
+        .c0_sys_clk_0_clk_n(c0_sys_clk_n),
+    {% endif %}
 
         // PCIe I/O
         .pcie_clk_clk_n(pcie_clk_clk_n),
@@ -701,6 +762,26 @@ module cyt_top (
         .c3_ddr4_dqs_c(c3_ddr4_dqs_c),
         .c3_sys_clk_p(c3_sys_clk_p),
         .c3_sys_clk_n(c3_sys_clk_n),
+    {% endif %}
+    {% if cnfg.en_dcard and cnfg.fpga_arch == 'versal' %}
+    {% for m in range(0, cnfg.n_ddr_chan) %}
+        .c{{ m }}_ddr4_act_n(c{{ m }}_ddr4_act_n),
+        .c{{ m }}_ddr4_adr(c{{ m }}_ddr4_adr),
+        .c{{ m }}_ddr4_ba(c{{ m }}_ddr4_ba),
+        .c{{ m }}_ddr4_bg(c{{ m }}_ddr4_bg),
+        .c{{ m }}_ddr4_ck_c(c{{ m }}_ddr4_ck_c),
+        .c{{ m }}_ddr4_ck_t(c{{ m }}_ddr4_ck_t),
+        .c{{ m }}_ddr4_cke(c{{ m }}_ddr4_cke),
+        .c{{ m }}_ddr4_cs_n(c{{ m }}_ddr4_cs_n),
+        .c{{ m }}_ddr4_dm_n(c{{ m }}_ddr4_dm_n),
+        .c{{ m }}_ddr4_dq(c{{ m }}_ddr4_dq),
+        .c{{ m }}_ddr4_dqs_c(c{{ m }}_ddr4_dqs_c),
+        .c{{ m }}_ddr4_dqs_t(c{{ m }}_ddr4_dqs_t),
+        .c{{ m }}_ddr4_odt(c{{ m }}_ddr4_odt),
+        .c{{ m }}_ddr4_reset_n(c{{ m }}_ddr4_reset_n),
+        .c{{ m }}_sys_clk_p(c{{ m }}_sys_clk_p),
+        .c{{ m }}_sys_clk_n(c{{ m }}_sys_clk_n),
+    {% endfor %}
     {% endif %}
     {% if cnfg.fdev == 'u280' or cnfg.fdev == 'u50d' or cnfg.fdev == 'u55c' %}
         .hbm_clk_clk_p(hbm_clk_clk_p),

--- a/hw/templates/common/shell_top_tmplt.txt
+++ b/hw/templates/common/shell_top_tmplt.txt
@@ -223,6 +223,27 @@ module shell_top (
     (* io_buffer_type = "none" *) input  logic                              c3_sys_clk_p,
     (* io_buffer_type = "none" *) input  logic                              c3_sys_clk_n,
     {% endif %}
+    {% if cnfg.en_dcard and cnfg.fpga_arch == 'versal' %}
+    // VCK5000 DDR4 (over the NoC): 16Gb x16, 64-bit data (no ECC), 200 MHz sysclk
+    {% for m in range(0, cnfg.n_ddr_chan) %}
+    (* io_buffer_type = "none" *) output logic                              c{{ m }}_ddr4_act_n,
+    (* io_buffer_type = "none" *) output logic[16:0]                        c{{ m }}_ddr4_adr,
+    (* io_buffer_type = "none" *) output logic[1:0]                         c{{ m }}_ddr4_ba,
+    (* io_buffer_type = "none" *) output logic[0:0]                         c{{ m }}_ddr4_bg,
+    (* io_buffer_type = "none" *) output logic[0:0]                         c{{ m }}_ddr4_ck_c,
+    (* io_buffer_type = "none" *) output logic[0:0]                         c{{ m }}_ddr4_ck_t,
+    (* io_buffer_type = "none" *) output logic[0:0]                         c{{ m }}_ddr4_cke,
+    (* io_buffer_type = "none" *) output logic[0:0]                         c{{ m }}_ddr4_cs_n,
+    (* io_buffer_type = "none" *) inout  logic[7:0]                         c{{ m }}_ddr4_dm_n,
+    (* io_buffer_type = "none" *) inout  logic[63:0]                        c{{ m }}_ddr4_dq,
+    (* io_buffer_type = "none" *) inout  logic[7:0]                         c{{ m }}_ddr4_dqs_c,
+    (* io_buffer_type = "none" *) inout  logic[7:0]                         c{{ m }}_ddr4_dqs_t,
+    (* io_buffer_type = "none" *) output logic[0:0]                         c{{ m }}_ddr4_odt,
+    (* io_buffer_type = "none" *) output logic                              c{{ m }}_ddr4_reset_n,
+    (* io_buffer_type = "none" *) input  logic                              c{{ m }}_sys_clk_p,
+    (* io_buffer_type = "none" *) input  logic                              c{{ m }}_sys_clk_n,
+    {% endfor %}
+    {% endif %}
     {% if cnfg.fdev == 'vcu118' %}
     // DDR4 0
     (* io_buffer_type = "none" *) output wire        			            c0_ddr4_act_n,
@@ -873,11 +894,17 @@ module shell_top (
 {% endif %}
 		
 {% endif %}
+{% if cnfg.en_mem and not cnfg.en_card %}
+    // Card memory requested (en_mem) but the device exposes no card memory (en_card=0, e.g.
+    // a host-only build on a device without HBM/DDR such as the VCK5000). Declare axi_mem so the
+    // dynamic wrapper's m_axi_ddr connection elaborates; it is left unconnected (no controller).
+    AXI4 #(.AXI4_DATA_BITS(AXI_DDR_BITS)) axi_mem [N_MEM_CHAN] ();
+{% endif %}
 {% if cnfg.en_card %}
     // ================-----------------------------------------------------------------
     // MEMORY STACK
     // ================-----------------------------------------------------------------
-    
+
     AXI4 #(.AXI4_DATA_BITS(AXI_DDR_BITS)) axi_mem [N_MEM_CHAN] ();
 	
 {% if cnfg.en_tcp and cnfg.en_rdma %}
@@ -891,7 +918,7 @@ module shell_top (
     axi_stripe (.aclk(aclk), .aresetn(aresetn), .s_axi(axi_ddr_rdma), .m_axi(axi_mem[0]));
 
 {% endif %}
-{% if cnfg.en_dcard %}
+{% if cnfg.en_dcard and cnfg.fpga_arch == 'ultrascale_plus' %}
     // ================-----------------------------------------------------------------
     // DDR
     // ================-----------------------------------------------------------------
@@ -1262,7 +1289,76 @@ module shell_top (
         .aclk(aclk),
         .aresetn(aresetn)
 	);
-{% endif %}	
+{% endif %}
+{% if cnfg.en_dcard and cnfg.fpga_arch == 'versal' %}
+    // ================-----------------------------------------------------------------
+    // DDR (Versal, over the NoC via integrated DDRMC --- VCK5000)
+    // ================-----------------------------------------------------------------
+    // Like the V80 HBM path, but the NoC NMU accepts the shell's 512-bit AXI directly at
+    // aclk, so axi_mem is tied straight to design_ddr's axi_ddr_in --- no cc_dwc / CDC.
+    design_ddr inst_int_ddr (
+    {% for i in range(0, cnfg.n_mem_chan) %}
+        .axi_ddr_in_{{ i }}_araddr(axi_mem[{{ i }}].araddr),
+        .axi_ddr_in_{{ i }}_arburst(axi_mem[{{ i }}].arburst),
+        .axi_ddr_in_{{ i }}_arcache(axi_mem[{{ i }}].arcache),
+        .axi_ddr_in_{{ i }}_arid(axi_mem[{{ i }}].arid),
+        .axi_ddr_in_{{ i }}_arlen(axi_mem[{{ i }}].arlen),
+        .axi_ddr_in_{{ i }}_arlock(axi_mem[{{ i }}].arlock),
+        .axi_ddr_in_{{ i }}_arprot(axi_mem[{{ i }}].arprot),
+        .axi_ddr_in_{{ i }}_arqos(axi_mem[{{ i }}].arqos),
+        .axi_ddr_in_{{ i }}_arready(axi_mem[{{ i }}].arready),
+        .axi_ddr_in_{{ i }}_arregion(axi_mem[{{ i }}].arregion),
+        .axi_ddr_in_{{ i }}_arsize(axi_mem[{{ i }}].arsize),
+        .axi_ddr_in_{{ i }}_arvalid(axi_mem[{{ i }}].arvalid),
+        .axi_ddr_in_{{ i }}_awaddr(axi_mem[{{ i }}].awaddr),
+        .axi_ddr_in_{{ i }}_awburst(axi_mem[{{ i }}].awburst),
+        .axi_ddr_in_{{ i }}_awcache(axi_mem[{{ i }}].awcache),
+        .axi_ddr_in_{{ i }}_awid(axi_mem[{{ i }}].awid),
+        .axi_ddr_in_{{ i }}_awlen(axi_mem[{{ i }}].awlen),
+        .axi_ddr_in_{{ i }}_awlock(axi_mem[{{ i }}].awlock),
+        .axi_ddr_in_{{ i }}_awprot(axi_mem[{{ i }}].awprot),
+        .axi_ddr_in_{{ i }}_awqos(axi_mem[{{ i }}].awqos),
+        .axi_ddr_in_{{ i }}_awready(axi_mem[{{ i }}].awready),
+        .axi_ddr_in_{{ i }}_awregion(axi_mem[{{ i }}].awregion),
+        .axi_ddr_in_{{ i }}_awsize(axi_mem[{{ i }}].awsize),
+        .axi_ddr_in_{{ i }}_awvalid(axi_mem[{{ i }}].awvalid),
+        .axi_ddr_in_{{ i }}_bid(axi_mem[{{ i }}].bid),
+        .axi_ddr_in_{{ i }}_bready(axi_mem[{{ i }}].bready),
+        .axi_ddr_in_{{ i }}_bresp(axi_mem[{{ i }}].bresp),
+        .axi_ddr_in_{{ i }}_bvalid(axi_mem[{{ i }}].bvalid),
+        .axi_ddr_in_{{ i }}_rdata(axi_mem[{{ i }}].rdata),
+        .axi_ddr_in_{{ i }}_rid(axi_mem[{{ i }}].rid),
+        .axi_ddr_in_{{ i }}_rlast(axi_mem[{{ i }}].rlast),
+        .axi_ddr_in_{{ i }}_rready(axi_mem[{{ i }}].rready),
+        .axi_ddr_in_{{ i }}_rresp(axi_mem[{{ i }}].rresp),
+        .axi_ddr_in_{{ i }}_rvalid(axi_mem[{{ i }}].rvalid),
+        .axi_ddr_in_{{ i }}_wdata(axi_mem[{{ i }}].wdata),
+        .axi_ddr_in_{{ i }}_wlast(axi_mem[{{ i }}].wlast),
+        .axi_ddr_in_{{ i }}_wready(axi_mem[{{ i }}].wready),
+        .axi_ddr_in_{{ i }}_wstrb(axi_mem[{{ i }}].wstrb),
+        .axi_ddr_in_{{ i }}_wvalid(axi_mem[{{ i }}].wvalid),
+    {% endfor %}
+    {% for m in range(0, cnfg.n_ddr_chan) %}
+        .c{{ m }}_ddr4_act_n(c{{ m }}_ddr4_act_n),
+        .c{{ m }}_ddr4_adr(c{{ m }}_ddr4_adr),
+        .c{{ m }}_ddr4_ba(c{{ m }}_ddr4_ba),
+        .c{{ m }}_ddr4_bg(c{{ m }}_ddr4_bg),
+        .c{{ m }}_ddr4_ck_c(c{{ m }}_ddr4_ck_c),
+        .c{{ m }}_ddr4_ck_t(c{{ m }}_ddr4_ck_t),
+        .c{{ m }}_ddr4_cke(c{{ m }}_ddr4_cke),
+        .c{{ m }}_ddr4_cs_n(c{{ m }}_ddr4_cs_n),
+        .c{{ m }}_ddr4_dm_n(c{{ m }}_ddr4_dm_n),
+        .c{{ m }}_ddr4_dq(c{{ m }}_ddr4_dq),
+        .c{{ m }}_ddr4_dqs_c(c{{ m }}_ddr4_dqs_c),
+        .c{{ m }}_ddr4_dqs_t(c{{ m }}_ddr4_dqs_t),
+        .c{{ m }}_ddr4_odt(c{{ m }}_ddr4_odt),
+        .c{{ m }}_ddr4_reset_n(c{{ m }}_ddr4_reset_n),
+        .c{{ m }}_sys_clk_0_clk_n(c{{ m }}_sys_clk_n),
+        .c{{ m }}_sys_clk_0_clk_p(c{{ m }}_sys_clk_p),
+    {% endfor %}
+        .aclk(aclk)
+	);
+{% endif %}
 {% if cnfg.en_hcard and cnfg.fpga_arch == 'ultrascale_plus' %}
     // ================-----------------------------------------------------------------
     // HBM

--- a/hw/templates/versal/static_top_tmplt.txt
+++ b/hw/templates/versal/static_top_tmplt.txt
@@ -56,6 +56,27 @@ module static_top (
     // Writeback interface
     metaIntf.s                              s_wback,
 
+{% if cnfg.fdev == 'vck5000' %}
+    // STATIC DDR4 (integrated MC backing the CPM4 QDMA NoC path): 16Gb x16, 64-bit, 200 MHz sysclk
+    // These physical pins come straight from design_static's axi_noc integrated DDR MC.
+    (* io_buffer_type = "none" *) output wire                 c0_ddr4_act_n,
+    (* io_buffer_type = "none" *) output wire[16:0]           c0_ddr4_adr,
+    (* io_buffer_type = "none" *) output wire[1:0]            c0_ddr4_ba,
+    (* io_buffer_type = "none" *) output wire[0:0]            c0_ddr4_bg,
+    (* io_buffer_type = "none" *) output wire[0:0]            c0_ddr4_ck_c,
+    (* io_buffer_type = "none" *) output wire[0:0]            c0_ddr4_ck_t,
+    (* io_buffer_type = "none" *) output wire[0:0]            c0_ddr4_cke,
+    (* io_buffer_type = "none" *) output wire[0:0]            c0_ddr4_cs_n,
+    (* io_buffer_type = "none" *) inout  wire[7:0]            c0_ddr4_dm_n,
+    (* io_buffer_type = "none" *) inout  wire[63:0]           c0_ddr4_dq,
+    (* io_buffer_type = "none" *) inout  wire[7:0]            c0_ddr4_dqs_c,
+    (* io_buffer_type = "none" *) inout  wire[7:0]            c0_ddr4_dqs_t,
+    (* io_buffer_type = "none" *) output wire[0:0]            c0_ddr4_odt,
+    (* io_buffer_type = "none" *) output wire                 c0_ddr4_reset_n,
+    (* io_buffer_type = "none" *) input  wire                 c0_sys_clk_0_clk_p,
+    (* io_buffer_type = "none" *) input  wire                 c0_sys_clk_0_clk_n,
+{% endif %}
+
     // PCIe I/O
     // Note, since Versal supports both PCIe Gen4x16 and Gen5x8, we don't call it pcie_x16_* like on UltraScale+
     input  wire[0:0]                        pcie_clk_clk_n,
@@ -404,6 +425,26 @@ module static_top (
         .dsc_pr_sdi(qdma_dsc_pr.req.sdi),
         .dsc_pr_valid(qdma_dsc_pr.valid),
         
+{% if cnfg.fdev == 'vck5000' %}
+        // STATIC DDR4 + 200 MHz system clock (integrated MC in design_static)
+        .c0_ddr4_act_n(c0_ddr4_act_n),
+        .c0_ddr4_adr(c0_ddr4_adr),
+        .c0_ddr4_ba(c0_ddr4_ba),
+        .c0_ddr4_bg(c0_ddr4_bg),
+        .c0_ddr4_ck_c(c0_ddr4_ck_c),
+        .c0_ddr4_ck_t(c0_ddr4_ck_t),
+        .c0_ddr4_cke(c0_ddr4_cke),
+        .c0_ddr4_cs_n(c0_ddr4_cs_n),
+        .c0_ddr4_dm_n(c0_ddr4_dm_n),
+        .c0_ddr4_dq(c0_ddr4_dq),
+        .c0_ddr4_dqs_c(c0_ddr4_dqs_c),
+        .c0_ddr4_dqs_t(c0_ddr4_dqs_t),
+        .c0_ddr4_odt(c0_ddr4_odt),
+        .c0_ddr4_reset_n(c0_ddr4_reset_n),
+        .c0_sys_clk_0_clk_p(c0_sys_clk_0_clk_p),
+        .c0_sys_clk_0_clk_n(c0_sys_clk_0_clk_n),
+{% endif %}
+
         // Clocks, resets
         .pcie_clk_clk_n(pcie_clk_clk_n),
         .pcie_clk_clk_p(pcie_clk_clk_p),

--- a/scripts/cr_prjcts/cr_shell.tcl.in
+++ b/scripts/cr_prjcts/cr_shell.tcl.in
@@ -45,6 +45,14 @@ puts "[color $clr_flow "**"]"
 
 # Create project
 set proj_dir "$build_dir/$project\_shell"
+# VCK5000: the vck5000 board part is absent from Vivado 2023.2's catalog but present in the
+# 2022.1 install (schema 2.1, same era). Point at it BEFORE create_project so get_board_parts
+# picks it up --- design_ddr's NoC DDR4 board interfaces + pin assignment depend on it.
+if {$cfg(fdev) eq "vck5000"} {
+    foreach _rp {/tools/Xilinx/Vivado/2022.1/data/boards/board_files /tools/Xilinx/Vivado/2024.2/data/boards/board_files} {
+        if {[file isdirectory $_rp]} { set_param board.repoPaths $_rp; break }
+    }
+}
 create_project $project $proj_dir -part $part -force
 set proj [current_project]
 set_property IP_REPO_PATHS $lib_dir [current_fileset]
@@ -62,6 +70,12 @@ file mkdir "$log_dir/shell"
 # SET PROJECT PROPERTIES
 ########################################################################################################
 #set_property "board_part" $board_part                      $proj
+# VCK5000: set the board part so design_ddr's NoC DDR4 board interfaces (ddr4_sdram_c*,
+# ddr4_c*_sysclk) resolve and the DDR4 pins are auto-assigned from the board file.
+if {$cfg(fdev) eq "vck5000"} {
+    set _bp [lindex [get_board_parts *vck5000* -quiet] end]
+    if {$_bp ne ""} { set_property board_part $_bp $proj }
+}
 set_property "default_lib" "xil_defaultlib"                 $proj
 set_property "ip_cache_permissions" "read write"            $proj
 set_property "ip_output_repo" "$proj_dir/$project.cache/ip" $proj

--- a/scripts/cr_prjcts/cr_static.tcl.in
+++ b/scripts/cr_prjcts/cr_static.tcl.in
@@ -45,6 +45,14 @@ puts "[color $clr_flow "**"]"
 
 # Create project
 set proj_dir "$build_dir/$project\_static"
+# VCK5000: the vck5000 board part is absent from Vivado 2023.2's catalog but present in the
+# 2022.1 install (schema 2.1, same era). Point at it BEFORE create_project so get_board_parts
+# picks it up --- design_static's integrated DDR MC board interface + pin assignment depend on it.
+if {$cfg(fdev) eq "vck5000"} {
+    foreach _rp {/tools/Xilinx/Vivado/2022.1/data/boards/board_files /tools/Xilinx/Vivado/2024.2/data/boards/board_files} {
+        if {[file isdirectory $_rp]} { set_param board.repoPaths $_rp; break }
+    }
+}
 create_project $project $proj_dir -part $part -force
 set proj [current_project]
 set_property IP_REPO_PATHS $lib_dir [current_fileset]
@@ -61,6 +69,12 @@ file mkdir "$log_dir/static"
 # SET PROJECT PROPERTIES
 ########################################################################################################
 #set_property "board_part" $board_part                      $proj
+# VCK5000: set the board part so design_static's integrated DDR MC board interface (c0_ddr4,
+# c0_sys_clk_0) resolves and the DDR4 pins are auto-assigned from the board file.
+if {$cfg(fdev) eq "vck5000"} {
+    set _bp [lindex [get_board_parts *vck5000* -quiet] end]
+    if {$_bp ne ""} { set_property board_part $_bp $proj }
+}
 set_property "default_lib" "xil_defaultlib"                 $proj
 set_property "ip_cache_permissions" "read write"            $proj
 set_property "ip_output_repo" "$proj_dir/$project.cache/ip" $proj

--- a/scripts/ip_inst/memory_infrastructure.tcl
+++ b/scripts/ip_inst/memory_infrastructure.tcl
@@ -2,8 +2,10 @@
 ## MEMORY IPs
 ## 
 
-# HBM clock generators
-if {$cfg(fpga_arch) eq "versal"} {
+# HBM clock generators --- only for Versal HBM cards (the clk_gen_hbm IP is instantiated
+# solely in the en_hcard shell_top branch). DDR-only Versal cards (e.g. vck5000) have no
+# HBM and hclk_f=1, which is out of the clk_wizard's valid range (5-1070 MHz).
+if {$cfg(fpga_arch) eq "versal" && $cfg(en_hcard) eq 1} {
     create_ip -name clk_wizard -vendor xilinx.com -library ip -version 1.0 -module_name clk_gen_hbm
     set cmd "set_property -dict \[list \
         CONFIG.CLKOUT_DRIVES {BUFG} \


### PR DESCRIPTION
WIP  

Current status:
- pass test on 07_perf_fpga, with gen3 x16 CPM4 under vivado 2022.1
- add versal ddr block desgin
- fix the driver to adapt for the difference between CPM5 and CPM4 register
- H2C 12.2 GB/s, C2H 13.2 GB/s

Known Issue:
- CPM PCIe failed training with vivado 2023.2
- license issue of build xcvc1902 device on vivado higher than 2024.2

## Description
> :memo: Please include a summary of the change

## Type of change
- [ ] Bug fix
- [*] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results
> :memo: Please describe the tests that you ran to verify your changes. Also include any numerical results (throughput/latency etc.) relavant to the change.

### Checklist
- [ ] I have commented my code and made corresponding changes to the documentation.
- [ ] I have added tests/results that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings or errors & all tests successfully pass.
