### PR TITLE
Update SpinalHDL toolchain in `build.sbt`

### DIFF
--- a/scripts/apps/build.sbt
+++ b/scripts/apps/build.sbt
@@ -1,10 +1,10 @@
-val spinalVersion = "1.12.0"
+val spinalVersion = "1.14.2"
 
 lazy val root = (project in file("."))
   .settings(
     name         := "coyote-spinal-kernel",
     version      := "1.0",
-    scalaVersion := "2.13.12",
+    scalaVersion := "2.13.18",
 
     libraryDependencies ++= Seq(
       "com.github.spinalhdl" %% "spinalhdl-core" % spinalVersion,


### PR DESCRIPTION
## Description

Update the SpinalHDL and Scala 2 versions in `build.sbt` to the respective current releases.

Without this, some code passing in the current version, fails due to a new overloaded method introduced in the current Scala 2 version, which has been fixed in SpinalHDL 1.12.3. So if there is a reason not to use the newest currently available versions, SpinalHDL should be updated at least to version 1.12.3.

Additionally, the current Scala 2 version should be compatible across all JDKs 8 to 26 according to their release notes:

https://github.com/scala/scala/releases#release-v2.13.18


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results
> :memo: Please describe the tests that you ran to verify your changes. Also include any numerical results (throughput/latency etc.) relevant to the change.
I've run synthesis with the unchanged Scala 2 version and SpinalHDL 1.12.3 as well as both updated to the current releases. The module works both in simulation and hardware for both combinations.

### Checklist
- [ ] I have commented my code and made corresponding changes to the documentation.
- [x] I have added tests/results that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings or errors & all tests successfully pass.
