### PR TITLE
DENIM (Dynamic endpoint network impairment model) semester project

### DIFF
--- a/cmake/FindCoyoteHW.cmake
+++ b/cmake/FindCoyoteHW.cmake
@@ -148,6 +148,10 @@ set(N_TCP_AXI 1 CACHE STRING "Number of TCP/IP streams")
 set(EN_SNIFFER 0 CACHE STRING "Enable packet sniffer.")
 set(SNIFFER_VFPGA_ID 0 CACHE STRING "ID of vFPGA to receive packet sniffer data stream.")
 
+# DENIM, in-path network impairment (ECN marking, drop, delay) on the RX path
+set(EN_DENIM 0 CACHE STRING "Enable DENIM.")
+set(DENIM_VFPGA_ID 0 CACHE STRING "ID of vFPGA holding the DENIM control registers.")
+
 # Use QSFP port 0
 set(EN_NET_0 1 CACHE STRING "QSFP port 0")
 
@@ -592,7 +596,7 @@ macro(validation_checks_hw)
         endif()
 
         # Top net enabled
-        if(EN_RDMA OR EN_TCP OR EN_SNIFFER)
+        if(EN_RDMA OR EN_TCP OR EN_SNIFFER OR EN_DENIM)
             set(EN_NET 1)
         else()
             set(EN_NET 0)

--- a/examples/13_denim/README.md
+++ b/examples/13_denim/README.md
@@ -26,13 +26,15 @@ under first-match-wins, two rules with identical conditions would never both fir
 
 | | |
 |---|---|
-| Conditions | `qpn N`, `psn N`, `psn A-B`, `psn +K`, `src_ip a.b.c.d`, `dst_ip a.b.c.d`, `opcode 0xNN` |
+| Conditions | `qpn N`, `psn N`, `psn A-B`, `psn +K`, `psn +A-B`, `src_ip a.b.c.d`, `dst_ip a.b.c.d`, `opcode 0xNN` |
 | Effects | `ecn`, `drop`, `delay <t>` (`ns` or `us`), `count` |
+| Limits | `once`, `shots N` = how many packets the rule may act on before it disarms |
 
 ```
 qpn 3, psn 50-150   : delay 1us       # emulate queueing over a PSN window
 src_ip 10.1.212.62  : ecn             # fake congestion signal per sender
 qpn 2, psn +100     : drop            # single loss at a relative PSN
+qpn 0, psn +10-15   : ecn             # mark a window six packets wide
 qpn 2               : count           # monitor only, no effect
 qpn 4, psn 0-500    : ecn, delay 2us  # two effects on one packet
 ```
@@ -41,9 +43,21 @@ Match values are written as plain host integers, `src_ip 10.1.212.62` is
 `0x0A01D43E`. The conversion to network byte order happens in hardware, at
 field extraction, so nothing in software byte-swaps.
 
-`psn +K` is relative to the connection's initial PSN.
+`psn +K` and `psn +A-B` are relative to the connection's initial PSN. That only
+exists at run time, so the **filter** resolves it: the first packet matching the
+rule's other conditions defines a base, which is used for both bounds. Until
+that happens the rule matches nothing, and `--status` reports the slot as
+`[waiting for first packet]` rather than `[armed]`.
 
 There are **8 slots**. `count` exists for dry runs.
+
+`shots N` is the bound. The rule acts on at most N packets and then disarms
+itself.
+
+```
+qpn 0, psn +10-15 : drop, shots 6      # six drops
+qpn 0, psn +10    : drop, once         # exactly one, the shorthand for shots 1
+```
 
 ## Building
 

--- a/examples/13_denim/README.md
+++ b/examples/13_denim/README.md
@@ -1,0 +1,126 @@
+# Example 13: DENIM (Dynamic Endpoint Network Impairment Model)
+
+DENIM applies configurable impairments: ECN marking, drop, delay to RoCE v2
+traffic **before it reaches the RDMA stack**. It lets network
+research (e.g. congestion control in the context of RDMA) trigger deterministic, reproducible network events on a two-node setup
+with no programmable switch in the path.
+
+The impairment datapath lives in the shell's service layer, in series on the RX
+stream between the CMAC and the IP handler, and ahead of the packet sniffer tap
+so captures show traffic as the RDMA stack will actually see it. This example
+is the **control plane**: a vFPGA exposing the rule table and counters, plus
+`denim_ctl` to drive them.
+
+With no rule armed, a DENIM shell is transparent apart from a few cycles of
+store-and-forward latency.
+
+## Rule grammar
+
+```
+<condition>[, <condition>...] : <effect>[, <effect>...]
+```
+
+Conditions are AND-ed and omitted fields are wildcards. The first matching rule
+wins and **all** of its effects apply. Effects therefore chain *inside* a rule:
+under first-match-wins, two rules with identical conditions would never both fire.
+
+| | |
+|---|---|
+| Conditions | `qpn N`, `psn N`, `psn A-B`, `psn +K`, `src_ip a.b.c.d`, `dst_ip a.b.c.d`, `opcode 0xNN` |
+| Effects | `ecn`, `drop`, `delay <t>` (`ns` or `us`), `count` |
+
+```
+qpn 3, psn 50-150   : delay 1us       # emulate queueing over a PSN window
+src_ip 10.1.212.62  : ecn             # fake congestion signal per sender
+qpn 2, psn +100     : drop            # single loss at a relative PSN
+qpn 2               : count           # monitor only, no effect
+qpn 4, psn 0-500    : ecn, delay 2us  # two effects on one packet
+```
+
+Match values are written as plain host integers, `src_ip 10.1.212.62` is
+`0x0A01D43E`. The conversion to network byte order happens in hardware, at
+field extraction, so nothing in software byte-swaps.
+
+`psn +K` is relative to the connection's initial PSN.
+
+There are **8 slots**. `count` exists for dry runs.
+
+## Building
+
+**Hardware**, on a build server (e.g. `hacc-build-*`):
+
+```bash
+module load vivado/2024.1
+mkdir build_hw && cd build_hw
+cmake ../examples/13_denim/hw -DFDEV_NAME=u55c
+make project && make bitgen
+```
+
+**Software**, on the FPGA node itself:
+
+```bash
+cd examples/13_denim/sw
+mkdir build_$(hostname -s) && cd build_$(hostname -s)
+cmake .. && make -j
+```
+
+## Using it
+
+```bash
+./denim_ctl --status                              # counters and installed rules
+./denim_ctl --load ../rules/example.rules         # install a rule set
+./denim_ctl --slot 2 --rule "qpn 7 : drop"        # one slot, mid-experiment
+./denim_ctl --clear 2                             # disarm one slot
+./denim_ctl --clear                               # disarm all
+./denim_ctl --global-en 0                         # disarm everything, keep the rules
+./denim_ctl --clear-counters
+```
+
+`--load` parses the whole file before touching a register, so a typo on the
+last line cannot leave half a rule set installed. It then drops `GLOBAL_EN`,
+rewrites every slot, and re-enables. Each install is read back and compared against what was asked for.
+
+`--nclk` must match the `NCLK_F` the bitstream was built with (250 MHz by
+default), since it converts delay times into clock cycles.
+
+`denim_ctl` checks the hardware's `VERSION` register at startup and refuses to run on a mismatch.
+
+## Reading `--status`
+
+```
+slot     matched     overflow    rule
+   0       14203            0    src_ip 10.1.212.61 : ecn
+   1         101            0    qpn 3, psn 50-150 : delay 1us
+```
+
+- **matched**: packets that matched this slot, whatever its effects.
+- **overflow**: packets this rule's delay caused to be dropped because the
+  FIFO was full.
+
+Overflow drops are counted separately from intentional drops, so `dropped`
+rising means the experiment is working and `delay overflows` rising means it
+is not.
+
+`marked ECN` counts packets DENIM actually marked, so a packet that arrived
+already CE does not increment it.
+
+## Two-node experiment
+
+Node A runs a plain shell (with RDMA enabled, however), node B the DENIM shell, with `09_perf_rdma` driving
+traffic A → B. Claims can be validated using three independent witnesses:
+
+1. DENIM's own counters, via `--status`
+2. The stack's reaction: retransmissions and other metrics in `coyote_sysfs`,
+   plus A's completion times
+3. Ground-truth PCAP from the sniffer, which sits downstream of DENIM and so
+   records the traffic as modified
+
+
+## Limitations
+
+IPv4 only, no VLAN tags, fixed 20-byte IPv4 headers, RX path only.
+Non-conforming packets pass through unmatched.
+
+Rules are stateless. "Drop the retransmission" or "drop every tenth packet"
+would need per-connection state in hardware. Similar patterns are reachable
+meanwhile by arming and disarming rules over time and by using PSN (relative) ranges.

--- a/examples/13_denim/hw/CMakeLists.txt
+++ b/examples/13_denim/hw/CMakeLists.txt
@@ -1,0 +1,65 @@
+######################################################################################
+# This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+#
+# MIT Licence
+# Copyright (c) 2026, Systems Group, ETH Zurich
+# All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+######################################################################################
+
+cmake_minimum_required(VERSION 3.5)
+set(CYT_DIR ${CMAKE_SOURCE_DIR}/../../../)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CYT_DIR}/cmake)
+find_package(CoyoteHW REQUIRED)
+
+project(example_13_denim)
+message("*** Coyote Example 13: DENIM (Network Impairment) [Hardware] ***")
+
+set(BUILD_OPT 1)
+
+# One vFPGA, holding the DENIM control registers and a full RDMA endpoint. The
+# impairment datapath is in the shell, not here, the endpoint wiring exists so
+# the evaluation node terminates RoCE v2 itself. 
+set(N_REGIONS 1)
+set(EN_STRM 1)
+set(N_STRM_AXI 2)
+set(EN_MEM 0)
+
+set(EN_RDMA 1)
+
+# DENIM itself
+set(EN_DENIM 1)
+set(DENIM_VFPGA_ID 0)
+
+# DENIM is placed upstream of the  sniffer tap in the shell, so enabling both gives 
+# captures of post-impairment traffic. However, using them also needs the capture and DMA pipeline from
+# example 11 in this vFPGA. This example is the control plane on its own.
+set(EN_SNIFFER 0)
+
+# Confirm that the selected options are allowed
+validation_checks_hw()
+
+# Load a user application in Configuration #0, Region #0
+load_apps (
+    VFPGA_C0_0 "src"
+)
+
+# Create the hardware project
+create_hw()

--- a/examples/13_denim/hw/src/hdl/denim_slv.sv
+++ b/examples/13_denim/hw/src/hdl/denim_slv.sv
@@ -1,0 +1,298 @@
+/**
+ * This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+ *
+ * MIT Licence
+ * Copyright (c) 2026, Systems Group, ETH Zurich
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import lynxTypes::*;
+
+/**
+ * @brief   DENIM control register slave
+ *
+ * Bridges the host's setCSR/getCSR to the DENIM datapath, which lives in the
+ * network clock domain. Writes are forwarded as {addr, data} beats on the
+ * config channel. Reads are served from a shadow of the register file that
+ * DENIM streams back continuously.
+ */
+module denim_slv (
+  input  logic                        aclk,
+  input  logic                        aresetn,
+
+  AXI4L.s                             axi_ctrl,
+
+  /* To the DENIM datapath, crossed to nclk in network_top */
+  metaIntf.m                          denim_cnfg,
+  metaIntf.s                          denim_stat
+);
+
+// -- Decl ----------------------------------------------------------
+// ------------------------------------------------------------------
+// 8 global registers plus 8 slots of 8. Sized from the same numbers as
+// denim_pkg.
+localparam integer N_RULES_L = 8;
+localparam integer N_REGS    = 8 + N_RULES_L * 8;
+localparam integer ADDR_LSB  = $clog2(AXIL_DATA_BITS/8);
+localparam integer ADDR_MSB  = $clog2(N_REGS);
+localparam integer AXI_ADDR_BITS = ADDR_LSB + ADDR_MSB;
+
+localparam integer REG_SLV_STATUS = 7;
+
+// Internal registers
+logic [AXI_ADDR_BITS-1:0] axi_awaddr;
+logic axi_awready;
+logic [AXI_ADDR_BITS-1:0] axi_araddr;
+logic axi_arready;
+logic [1:0] axi_bresp;
+logic axi_bvalid;
+logic axi_wready;
+logic [AXIL_DATA_BITS-1:0] axi_rdata;
+logic [1:0] axi_rresp;
+logic axi_rvalid;
+
+logic slv_reg_rden;
+logic slv_reg_wren;
+logic aw_en;
+
+
+/**
+ * Config writes
+ */
+logic [71:0] cfg_data_r;
+logic        cfg_valid_r;
+logic        cfg_lost;
+logic        cfg_partial;
+logic        wr_pending;
+logic        cfg_wr;
+
+assign slv_reg_wren = axi_wready && axi_ctrl.wvalid && axi_awready && axi_ctrl.awvalid;
+
+// A write beat leaves only for a write that actually carries bytes.
+assign cfg_wr = slv_reg_wren && (|axi_ctrl.wstrb);
+
+// One config beat per completed write transaction, gated on wr_pending.
+always_ff @(posedge aclk) begin
+  if (aresetn == 1'b0) begin
+    cfg_data_r  <= '0;
+    cfg_valid_r <= 1'b0;
+    cfg_lost    <= 1'b0;
+    cfg_partial <= 1'b0;
+    wr_pending  <= 1'b0;
+  end
+  else begin
+    if (denim_cnfg.valid && denim_cnfg.ready) begin
+      cfg_valid_r <= 1'b0;
+    end
+
+    // A whole word crosses at a time, so a partial write cannot be honoured.
+    if (cfg_wr && !(&axi_ctrl.wstrb)) begin
+      cfg_partial <= 1'b1;
+    end
+
+    if (cfg_wr && !wr_pending) begin
+      if (cfg_valid_r && !(denim_cnfg.valid && denim_cnfg.ready)) begin
+        cfg_lost <= 1'b1;
+      end
+      else begin
+        cfg_data_r  <= {axi_awaddr[ADDR_LSB+:ADDR_MSB], axi_ctrl.wdata};
+        cfg_valid_r <= 1'b1;
+      end
+      wr_pending <= 1'b1;
+    end
+
+    if (!axi_ctrl.awvalid) begin
+      wr_pending <= 1'b0;
+    end
+  end
+end
+
+assign denim_cnfg.data  = cfg_data_r;
+assign denim_cnfg.valid = cfg_valid_r;
+
+/**
+ * Register mirror
+ */
+// DENIM walks its whole register file onto this channel continuously, so the
+// shadow converges within one pass and a dropped beat heals on the next.
+logic [AXIL_DATA_BITS-1:0] shadow [N_REGS];
+
+assign denim_stat.ready = 1'b1;
+
+always_ff @(posedge aclk) begin
+  if (aresetn == 1'b0) begin
+    for (int i = 0; i < N_REGS; i++) shadow[i] <= '0;
+  end
+  else if (denim_stat.valid && denim_stat.ready) begin
+    if (denim_stat.data[71:64] < N_REGS) begin
+      shadow[denim_stat.data[71:64]] <= denim_stat.data[63:0];
+    end
+  end
+end
+
+/**
+ * Reads
+ */
+assign slv_reg_rden = axi_arready & axi_ctrl.arvalid & ~axi_rvalid;
+
+always_ff @(posedge aclk) begin
+  if (aresetn == 1'b0) begin
+    axi_rdata <= 0;
+  end
+  else begin
+    if (slv_reg_rden) begin
+      if (axi_araddr[ADDR_LSB+:ADDR_MSB] == REG_SLV_STATUS[ADDR_MSB-1:0]) begin
+        axi_rdata <= {62'd0, cfg_partial, cfg_lost};
+      end
+      else begin
+        axi_rdata <= shadow[axi_araddr[ADDR_LSB+:ADDR_MSB]];
+      end
+    end
+  end
+end
+
+// AXI CTRL  
+// Don't edit
+
+// I/O
+assign axi_ctrl.awready = axi_awready;
+assign axi_ctrl.arready = axi_arready;
+assign axi_ctrl.bresp = axi_bresp;
+assign axi_ctrl.bvalid = axi_bvalid;
+assign axi_ctrl.wready = axi_wready;
+assign axi_ctrl.rdata = axi_rdata;
+assign axi_ctrl.rresp = axi_rresp;
+assign axi_ctrl.rvalid = axi_rvalid;
+
+// awready and awaddr
+always_ff @(posedge aclk) begin
+  if ( aresetn == 1'b0 )
+    begin
+      axi_awready <= 1'b0;
+      axi_awaddr <= 0;
+      aw_en <= 1'b1;
+    end 
+  else
+    begin    
+      if (~axi_awready && axi_ctrl.awvalid && axi_ctrl.wvalid && aw_en)
+        begin
+          axi_awready <= 1'b1;
+          aw_en <= 1'b0;
+          axi_awaddr <= axi_ctrl.awaddr;
+        end
+      else if (axi_ctrl.bready && axi_bvalid)
+        begin
+          aw_en <= 1'b1;
+          axi_awready <= 1'b0;
+        end
+      else           
+        begin
+          axi_awready <= 1'b0;
+        end
+    end 
+end  
+
+// arready and araddr
+always_ff @(posedge aclk) begin
+  if ( aresetn == 1'b0 )
+    begin
+      axi_arready <= 1'b0;
+      axi_araddr  <= 0;
+    end 
+  else
+    begin    
+      if (~axi_arready && axi_ctrl.arvalid)
+        begin
+          axi_arready <= 1'b1;
+          axi_araddr  <= axi_ctrl.araddr;
+        end
+      else
+        begin
+          axi_arready <= 1'b0;
+        end
+    end 
+end    
+
+// bvalid and bresp
+always_ff @(posedge aclk) begin
+  if ( aresetn == 1'b0 )
+    begin
+      axi_bvalid  <= 0;
+      axi_bresp   <= 2'b0;
+    end 
+  else
+    begin    
+      if (axi_awready && axi_ctrl.awvalid && ~axi_bvalid && axi_wready && axi_ctrl.wvalid)
+        begin
+          axi_bvalid <= 1'b1;
+          axi_bresp  <= 2'b0;
+        end                   
+      else
+        begin
+          if (axi_ctrl.bready && axi_bvalid) 
+            begin
+              axi_bvalid <= 1'b0; 
+            end  
+        end
+    end
+end
+
+// wready
+always_ff @(posedge aclk) begin
+  if ( aresetn == 1'b0 )
+    begin
+      axi_wready <= 1'b0;
+    end 
+  else
+    begin    
+      if (~axi_wready && axi_ctrl.wvalid && axi_ctrl.awvalid && aw_en )
+        begin
+          axi_wready <= 1'b1;
+        end
+      else
+        begin
+          axi_wready <= 1'b0;
+        end
+    end 
+end  
+
+// rvalid and rresp
+always_ff @(posedge aclk) begin
+  if ( aresetn == 1'b0 )
+    begin
+      axi_rvalid <= 0;
+      axi_rresp  <= 0;
+    end 
+  else
+    begin    
+      if (axi_arready && axi_ctrl.arvalid && ~axi_rvalid)
+        begin
+          axi_rvalid <= 1'b1;
+          axi_rresp  <= 2'b0;
+        end   
+      else if (axi_rvalid && axi_ctrl.rready)
+        begin
+          axi_rvalid <= 1'b0;
+        end                
+    end
+end    
+
+endmodule

--- a/examples/13_denim/hw/src/init_ip.tcl
+++ b/examples/13_denim/hw/src/init_ip.tcl
@@ -1,0 +1,3 @@
+# The DENIM control vFPGA needs no IP. It is a CSR window onto the rule table
+# and the counters. The impairment datapath lives in the shell's service layer.
+# The file is kept because the build flow sources it for every application.

--- a/examples/13_denim/hw/src/vfpga_top.svh
+++ b/examples/13_denim/hw/src/vfpga_top.svh
@@ -1,0 +1,75 @@
+/**
+ * This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+ *
+ * MIT Licence
+ * Copyright (c) 2026, Systems Group, ETH Zurich
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+// DENIM control vFPGA, plus a full RDMA endpoint.
+//
+// The impairment datapath lives in the shell's service layer, in series on the
+// RX stream, so DENIM itself needs nothing from this application beyond the CSR
+// window onto the rule table and the counters.
+//
+// The RDMA wiring below is here because the evaluation node has to be a real
+// RDMA endpoint as well: DENIM impairs traffic on the way to its own node's
+// RoCE stack, so the effect is only observable if that stack actually
+// terminates the connection and reacts.
+// Wiring copied from examples/09_perf_rdma so the two nodes present the same
+// endpoint behaviour and only DENIM differs. The one deviation: 09 ties off
+// axi_ctrl, which here belongs to denim_slv.
+always_comb begin
+    // Network write/read requests from the host become Coyote send queue entries
+    sq_wr.valid = rq_wr.valid;
+    rq_wr.ready = sq_wr.ready;
+    sq_wr.data  = rq_wr.data;
+    sq_wr.data.strm = STRM_HOST;        // For RDMA, data is always on the host
+    sq_wr.data.dest = is_opcode_rd_resp(rq_wr.data.opcode) ? 0 : 1;
+
+    sq_rd.valid = rq_rd.valid;
+    rq_rd.ready = sq_rd.ready;
+    sq_rd.data  = rq_rd.data;
+    sq_rd.data.strm = STRM_HOST;
+    sq_rd.data.dest = 1;
+end
+
+// Outgoing RDMA WRITEs (local host -> network stack -> remote node)
+`AXISR_ASSIGN(axis_host_recv[0], axis_rreq_send[0])
+// Incoming RDMA READ RESPONSEs (remote node -> network stack -> local host)
+`AXISR_ASSIGN(axis_rreq_recv[0], axis_host_send[0])
+// Outgoing RDMA READ RESPONSEs (local host -> network stack -> remote node)
+`AXISR_ASSIGN(axis_host_recv[1], axis_rrsp_send[0])
+// Incoming RDMA WRITEs (remote node -> network stack -> local host)
+`AXISR_ASSIGN(axis_rrsp_recv[0], axis_host_send[1])
+
+// No descriptors or interrupts, DENIM reports through its own counters.
+always_comb notify.tie_off_m();
+always_comb cq_rd.tie_off_s();
+always_comb cq_wr.tie_off_s();
+
+denim_slv inst_denim_slv (
+    .aclk(aclk),
+    .aresetn(aresetn),
+    .axi_ctrl(axi_ctrl),
+    .denim_cnfg(denim_cnfg),
+    .denim_stat(denim_stat)
+);

--- a/examples/13_denim/sw/CMakeLists.txt
+++ b/examples/13_denim/sw/CMakeLists.txt
@@ -1,0 +1,43 @@
+######################################################################################
+# This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+#
+# MIT Licence
+# Copyright (c) 2026, Systems Group, ETH Zurich
+# All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+######################################################################################
+
+cmake_minimum_required(VERSION 3.5)
+project(example_13_denim_sw CXX)
+
+set(TARGET_DIR "${CMAKE_SOURCE_DIR}/src")
+
+message("*** Coyote Example 13: DENIM [Software] ***")
+message("    Build this on the FPGA node itself, not on a build server.")
+
+add_subdirectory(../../../sw ${CMAKE_BINARY_DIR}/coyote)
+
+add_executable(denim_ctl ${TARGET_DIR}/main.cpp ${TARGET_DIR}/denim_rules.cpp)
+target_include_directories(denim_ctl PRIVATE ${TARGET_DIR})
+target_compile_features(denim_ctl PRIVATE cxx_std_17)
+target_link_libraries(denim_ctl PUBLIC Coyote)
+
+find_package(Boost REQUIRED COMPONENTS program_options)
+target_link_libraries(denim_ctl PUBLIC Boost::program_options)

--- a/examples/13_denim/sw/rules/example.rules
+++ b/examples/13_denim/sw/rules/example.rules
@@ -1,0 +1,11 @@
+# DENIM example rules.
+#
+# One rule per line. Line i goes to slot i, and the first matching slot wins,
+# so file order is match priority. Blank lines and # comments are ignored.
+#
+#   <condition>[, <condition>...] : <effect>[, <effect>...]
+src_ip 10.1.212.61 : ecn
+qpn 3, psn 50-150 : delay 1us
+qpn 3, psn 500 : drop
+qpn 4, psn 0-500 : ecn, delay 2us
+qpn 2 : count

--- a/examples/13_denim/sw/rules/example.rules
+++ b/examples/13_denim/sw/rules/example.rules
@@ -6,6 +6,6 @@
 #   <condition>[, <condition>...] : <effect>[, <effect>...]
 src_ip 10.1.212.61 : ecn
 qpn 3, psn 50-150 : delay 1us
-qpn 3, psn 500 : drop
+qpn 3, psn 500 : drop, once
 qpn 4, psn 0-500 : ecn, delay 2us
 qpn 2 : count

--- a/examples/13_denim/sw/src/denim_rules.cpp
+++ b/examples/13_denim/sw/src/denim_rules.cpp
@@ -1,0 +1,439 @@
+/**
+ * This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+ *
+ * MIT Licence
+ * Copyright (c) 2026, Systems Group, ETH Zurich
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "include/denim_rules.hpp"
+#include "include/denim_regs.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+
+namespace denim {
+
+namespace {
+
+std::string trim(const std::string &s) {
+    auto b = s.find_first_not_of(" \t\r\n");
+    if (b == std::string::npos) return {};
+    auto e = s.find_last_not_of(" \t\r\n");
+    return s.substr(b, e - b + 1);
+}
+
+std::vector<std::string> split(const std::string &s, char sep) {
+    std::vector<std::string> out;
+    size_t start = 0;
+    for (;;) {
+        const auto p = s.find(sep, start);
+        if (p == std::string::npos) {
+            out.push_back(trim(s.substr(start)));
+            return out;
+        }
+        out.push_back(trim(s.substr(start, p - start)));
+        start = p + 1;
+    }
+}
+
+std::vector<std::string> words(const std::string &s) {
+    std::vector<std::string> out;
+    std::istringstream is(s);
+    std::string w;
+    while (is >> w) out.push_back(w);
+    return out;
+}
+
+bool parse_uint(const std::string &s, uint64_t &out) {
+    if (s.empty()) return false;
+    size_t pos = 0;
+    int base = 10;
+    std::string body = s;
+    if (s.size() > 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) {
+        base = 16;
+        body = s.substr(2);
+        if (body.empty()) return false;
+    }
+    try {
+        out = std::stoull(body, &pos, base);
+    } catch (...) {
+        return false;
+    }
+    return pos == body.size();
+}
+
+bool parse_ipv4(const std::string &s, uint32_t &out) {
+    auto parts = split(s, '.');
+    if (parts.size() != 4) return false;
+    uint32_t v = 0;
+    for (const auto &p : parts) {
+        uint64_t o = 0;
+        if (p.empty() || !parse_uint(p, o) || o > 255) return false;
+        v = (v << 8) | static_cast<uint32_t>(o);
+    }
+    out = v;
+    return true;
+}
+
+// "1us" or "500ns" into network clock cycles. Nanoseconds are computed as
+// value * mhz / 1000, which truncates: at 250 MHz the finest representable
+bool parse_delay(const std::string &s, uint32_t nclk_mhz, uint32_t &cycles,
+                 std::string &err) {
+    if (nclk_mhz == 0) {
+        err = "network clock frequency is zero";
+        return false;
+    }
+    size_t unit = s.find_first_not_of("0123456789");
+    if (unit == std::string::npos || unit == 0) {
+        err = "delay '" + s + "' needs a value and a unit, e.g. 1us or 500ns";
+        return false;
+    }
+    uint64_t value = 0;
+    if (!parse_uint(s.substr(0, unit), value)) {
+        err = "delay '" + s + "' has a malformed value";
+        return false;
+    }
+    const std::string suffix = s.substr(unit);
+
+    uint64_t c;
+    if (suffix == "us") {
+        c = value * nclk_mhz;
+    } else if (suffix == "ns") {
+        c = value * nclk_mhz / 1000;
+        if (c == 0 && value != 0) {
+            err = "delay '" + s + "' is shorter than one clock cycle at " +
+                  std::to_string(nclk_mhz) + " MHz";
+            return false;
+        }
+    } else {
+        err = "delay unit '" + suffix + "' is not ns or us";
+        return false;
+    }
+
+    if (c > 0xFFFFFFFFull) {
+        err = "delay '" + s + "' does not fit in 32 bits of cycles";
+        return false;
+    }
+    cycles = static_cast<uint32_t>(c);
+    return true;
+}
+
+bool parse_condition(const std::string &cond, Rule &r, std::string &err) {
+    const auto w = words(cond);
+    if (w.empty()) {
+        err = "empty condition";
+        return false;
+    }
+    const std::string &key = w[0];
+
+    if (w.size() != 2) {
+        err = "condition '" + key + "' expects one argument";
+        return false;
+    }
+    const std::string &arg = w[1];
+
+    if (key == "qpn") {
+        uint64_t v;
+        if (!parse_uint(arg, v) || v > 0xFFFFFF) {
+            err = "qpn '" + arg + "' is not a 24 bit value";
+            return false;
+        }
+        r.qpn_en = true;
+        r.qpn = static_cast<uint32_t>(v);
+        return true;
+    }
+
+    if (key == "psn") {
+        r.psn_en = true;
+        if (arg[0] == '+') {
+            uint64_t v;
+            if (!parse_uint(arg.substr(1), v) || v > 0xFFFFFF) {
+                err = "psn offset '" + arg + "' is not a 24 bit value";
+                return false;
+            }
+            r.psn_relative = true;
+            r.psn_offset = static_cast<uint32_t>(v);
+            return true;
+        }
+        const auto dash = arg.find('-');
+        if (dash != std::string::npos) {
+            uint64_t lo, hi;
+            if (!parse_uint(arg.substr(0, dash), lo) ||
+                !parse_uint(arg.substr(dash + 1), hi)) {
+                err = "psn range '" + arg + "' is malformed";
+                return false;
+            }
+            if (lo > hi) {
+                err = "psn range '" + arg + "' has its bounds reversed";
+                return false;
+            }
+            if (hi > 0xFFFFFF) {
+                err = "psn range '" + arg + "' exceeds 24 bits";
+                return false;
+            }
+            r.psn_lo = static_cast<uint32_t>(lo);
+            r.psn_hi = static_cast<uint32_t>(hi);
+            return true;
+        }
+        uint64_t v;
+        if (!parse_uint(arg, v) || v > 0xFFFFFF) {
+            err = "psn '" + arg + "' is not a 24 bit value";
+            return false;
+        }
+        r.psn_lo = r.psn_hi = static_cast<uint32_t>(v);
+        return true;
+    }
+
+    if (key == "src_ip" || key == "dst_ip") {
+        uint32_t ip;
+        if (!parse_ipv4(arg, ip)) {
+            err = key + " '" + arg + "' is not a dotted quad";
+            return false;
+        }
+        if (key == "src_ip") {
+            r.src_en = true;
+            r.ip_src = ip;
+        } else {
+            r.dst_en = true;
+            r.ip_dst = ip;
+        }
+        return true;
+    }
+
+    if (key == "opcode") {
+        uint64_t v;
+        if (!parse_uint(arg, v) || v > 0xFF) {
+            err = "opcode '" + arg + "' is not an 8 bit value";
+            return false;
+        }
+        r.op_en = true;
+        r.opcode = static_cast<uint8_t>(v);
+        return true;
+    }
+
+    err = "unknown condition '" + key + "'";
+    return false;
+}
+
+bool parse_effect(const std::string &eff, Rule &r, uint32_t nclk_mhz,
+                  std::string &err) {
+    const auto w = words(eff);
+    if (w.empty()) {
+        err = "empty effect";
+        return false;
+    }
+    const std::string &key = w[0];
+
+    if (key == "ecn" || key == "drop" || key == "count") {
+        if (w.size() != 1) {
+            err = "effect '" + key + "' takes no argument";
+            return false;
+        }
+        r.eff_mask |= (key == "ecn") ? EFF_ECN : (key == "drop") ? EFF_DROP : EFF_COUNT;
+        return true;
+    }
+
+    if (key == "delay") {
+        if (w.size() != 2) {
+            err = "effect 'delay' needs a time, e.g. delay 1us";
+            return false;
+        }
+        uint32_t cycles;
+        if (!parse_delay(w[1], nclk_mhz, cycles, err)) return false;
+        r.eff_mask |= EFF_DELAY;
+        r.delay_cycles = cycles;
+        return true;
+    }
+
+    err = "unknown effect '" + key + "'";
+    return false;
+}
+
+} // namespace
+
+ParseResult parse_rule(const std::string &line, Rule &out, std::string &err,
+                       uint32_t nclk_mhz) {
+    out = Rule{};
+    err.clear();
+
+    std::string body = line;
+    const auto hash = body.find('#');
+    if (hash != std::string::npos) body = body.substr(0, hash);
+    body = trim(body);
+    if (body.empty()) return ParseResult::Skip;
+
+    const auto colon = body.find(':');
+    if (colon == std::string::npos) {
+        err = "no ':' separating conditions from effects";
+        return ParseResult::Error;
+    }
+
+    const std::string lhs = trim(body.substr(0, colon));
+    const std::string rhs = trim(body.substr(colon + 1));
+
+    if (rhs.empty()) {
+        err = "no effects given";
+        return ParseResult::Error;
+    }
+
+    // An empty left side is a rule with no conditions. It matches every RoCE
+    // packet. Allowed but easy to write by accident.
+    if (!lhs.empty()) {
+        for (const auto &c : split(lhs, ',')) {
+            if (c.empty()) {
+                err = "empty condition, check for a stray comma";
+                return ParseResult::Error;
+            }
+            if (!parse_condition(c, out, err)) return ParseResult::Error;
+        }
+    }
+
+    for (const auto &e : split(rhs, ',')) {
+        if (e.empty()) {
+            err = "empty effect, check for a stray comma";
+            return ParseResult::Error;
+        }
+        if (!parse_effect(e, out, nclk_mhz, err)) return ParseResult::Error;
+    }
+
+    return ParseResult::Ok;
+}
+
+void resolve_relative_psn(Rule &r, uint32_t initial_psn) {
+    if (!r.psn_relative) return;
+    r.psn_lo = r.psn_hi = (initial_psn + r.psn_offset) & 0xFFFFFF;
+    r.psn_relative = false;
+}
+
+std::vector<std::pair<uint32_t, uint64_t>> rule_to_csr_writes(const Rule &r, int slot) {
+    std::vector<std::pair<uint32_t, uint64_t>> w;
+
+    w.emplace_back(rule_reg(slot, FLD_MATCH_QPN),
+                   (r.qpn_en ? (1ull << 32) : 0ull) | r.qpn);
+
+    w.emplace_back(rule_reg(slot, FLD_MATCH_PSN),
+                   (r.psn_en ? (1ull << 56) : 0ull) |
+                   (static_cast<uint64_t>(r.psn_hi) << 32) | r.psn_lo);
+
+    w.emplace_back(rule_reg(slot, FLD_MATCH_IP),
+                   (static_cast<uint64_t>(r.ip_dst) << 32) | r.ip_src);
+
+    w.emplace_back(rule_reg(slot, FLD_MATCH_FLAGS),
+                   (r.src_en ? 1ull : 0ull) |
+                   (r.dst_en ? 2ull : 0ull) |
+                   (r.op_en  ? 4ull : 0ull) |
+                   (static_cast<uint64_t>(r.opcode) << 8));
+
+    w.emplace_back(rule_reg(slot, FLD_EFFECT_MASK), r.eff_mask);
+    w.emplace_back(rule_reg(slot, FLD_EFFECT_PARAM), r.delay_cycles);
+
+    w.emplace_back(rule_reg(slot, FLD_ENABLE), 1ull);
+    return w;
+}
+
+std::vector<std::pair<uint32_t, uint64_t>> rule_clear_writes(int slot) {
+    return {{rule_reg(slot, FLD_ENABLE), 0ull}};
+}
+
+Rule rule_from_regs(const uint64_t reg[8], bool &enabled) {
+    Rule r;
+    enabled = (reg[FLD_ENABLE] & 1ull) != 0;
+
+    r.qpn_en = (reg[FLD_MATCH_QPN] >> 32) & 1ull;
+    r.qpn    = static_cast<uint32_t>(reg[FLD_MATCH_QPN] & 0xFFFFFFull);
+
+    r.psn_en = (reg[FLD_MATCH_PSN] >> 56) & 1ull;
+    r.psn_lo = static_cast<uint32_t>(reg[FLD_MATCH_PSN] & 0xFFFFFFull);
+    r.psn_hi = static_cast<uint32_t>((reg[FLD_MATCH_PSN] >> 32) & 0xFFFFFFull);
+
+    r.ip_src = static_cast<uint32_t>(reg[FLD_MATCH_IP] & 0xFFFFFFFFull);
+    r.ip_dst = static_cast<uint32_t>(reg[FLD_MATCH_IP] >> 32);
+
+    r.src_en = reg[FLD_MATCH_FLAGS] & 1ull;
+    r.dst_en = (reg[FLD_MATCH_FLAGS] >> 1) & 1ull;
+    r.op_en  = (reg[FLD_MATCH_FLAGS] >> 2) & 1ull;
+    r.opcode = static_cast<uint8_t>((reg[FLD_MATCH_FLAGS] >> 8) & 0xFFull);
+
+    r.eff_mask     = static_cast<uint8_t>(reg[FLD_EFFECT_MASK] & 0xFull);
+    r.delay_cycles = static_cast<uint32_t>(reg[FLD_EFFECT_PARAM] & 0xFFFFFFFFull);
+
+    r.psn_relative = false;
+    return r;
+}
+
+std::string rule_to_string(const Rule &r, uint32_t nclk_mhz) {
+    std::ostringstream os;
+    std::vector<std::string> conds;
+
+    if (r.qpn_en) conds.push_back("qpn " + std::to_string(r.qpn));
+    if (r.psn_en) {
+        if (r.psn_relative) {
+            conds.push_back("psn +" + std::to_string(r.psn_offset));
+        } else if (r.psn_lo == r.psn_hi) {
+            conds.push_back("psn " + std::to_string(r.psn_lo));
+        } else {
+            conds.push_back("psn " + std::to_string(r.psn_lo) + "-" +
+                            std::to_string(r.psn_hi));
+        }
+    }
+    auto ip_str = [](uint32_t v) {
+        return std::to_string((v >> 24) & 0xFF) + "." + std::to_string((v >> 16) & 0xFF) +
+               "." + std::to_string((v >> 8) & 0xFF) + "." + std::to_string(v & 0xFF);
+    };
+    if (r.src_en) conds.push_back("src_ip " + ip_str(r.ip_src));
+    if (r.dst_en) conds.push_back("dst_ip " + ip_str(r.ip_dst));
+    if (r.op_en) {
+        std::ostringstream o;
+        o << "opcode 0x" << std::hex << static_cast<int>(r.opcode);
+        conds.push_back(o.str());
+    }
+
+    for (size_t i = 0; i < conds.size(); i++) {
+        os << conds[i];
+        if (i + 1 < conds.size()) os << ", ";
+    }
+
+    os << " : ";
+    std::vector<std::string> effs;
+    if (r.eff_mask & EFF_ECN) effs.push_back("ecn");
+    if (r.eff_mask & EFF_DROP) effs.push_back("drop");
+    if (r.eff_mask & EFF_DELAY) {
+        if (nclk_mhz != 0 && r.delay_cycles % nclk_mhz == 0) {
+            effs.push_back("delay " + std::to_string(r.delay_cycles / nclk_mhz) + "us");
+        } else if (nclk_mhz != 0) {
+            effs.push_back("delay " + std::to_string(r.delay_cycles * 1000 / nclk_mhz) + "ns");
+        } else {
+            effs.push_back("delay " + std::to_string(r.delay_cycles) + "cyc");
+        }
+    }
+    if (r.eff_mask & EFF_COUNT) effs.push_back("count");
+    if (effs.empty()) effs.push_back("(none)");
+
+    for (size_t i = 0; i < effs.size(); i++) {
+        os << effs[i];
+        if (i + 1 < effs.size()) os << ", ";
+    }
+    return os.str();
+}
+
+} // namespace denim

--- a/examples/13_denim/sw/src/denim_rules.cpp
+++ b/examples/13_denim/sw/src/denim_rules.cpp
@@ -138,6 +138,17 @@ bool parse_delay(const std::string &s, uint32_t nclk_mhz, uint32_t &cycles,
     return true;
 }
 
+// A relative window that includes offset zero can never match. The base is
+// captured from the packet that arms the rule.
+bool check_relative_zero(const Rule &r, const std::string &arg, std::string &err) {
+    if (r.psn_relative && r.psn_lo == 0) {
+        err = "psn '" + arg + "' includes offset 0, which can never match: the "
+              "base is captured from that packet, not matched against it";
+        return false;
+    }
+    return true;
+}
+
 bool parse_condition(const std::string &cond, Rule &r, std::string &err) {
     const auto w = words(cond);
     if (w.empty()) {
@@ -165,21 +176,23 @@ bool parse_condition(const std::string &cond, Rule &r, std::string &err) {
 
     if (key == "psn") {
         r.psn_en = true;
-        if (arg[0] == '+') {
-            uint64_t v;
-            if (!parse_uint(arg.substr(1), v) || v > 0xFFFFFF) {
-                err = "psn offset '" + arg + "' is not a 24 bit value";
+
+        std::string body = arg;
+        if (body[0] == '+') {
+            r.psn_relative = true;
+            body = body.substr(1);
+            if (body.empty()) {
+                err = "psn '" + arg + "' needs an offset after the '+'";
                 return false;
             }
-            r.psn_relative = true;
-            r.psn_offset = static_cast<uint32_t>(v);
-            return true;
         }
-        const auto dash = arg.find('-');
+        const std::string &arg_ = body;
+
+        const auto dash = arg_.find('-');
         if (dash != std::string::npos) {
             uint64_t lo, hi;
-            if (!parse_uint(arg.substr(0, dash), lo) ||
-                !parse_uint(arg.substr(dash + 1), hi)) {
+            if (!parse_uint(arg_.substr(0, dash), lo) ||
+                !parse_uint(arg_.substr(dash + 1), hi)) {
                 err = "psn range '" + arg + "' is malformed";
                 return false;
             }
@@ -193,15 +206,15 @@ bool parse_condition(const std::string &cond, Rule &r, std::string &err) {
             }
             r.psn_lo = static_cast<uint32_t>(lo);
             r.psn_hi = static_cast<uint32_t>(hi);
-            return true;
+            return check_relative_zero(r, arg, err);
         }
         uint64_t v;
-        if (!parse_uint(arg, v) || v > 0xFFFFFF) {
+        if (!parse_uint(arg_, v) || v > 0xFFFFFF) {
             err = "psn '" + arg + "' is not a 24 bit value";
             return false;
         }
         r.psn_lo = r.psn_hi = static_cast<uint32_t>(v);
-        return true;
+        return check_relative_zero(r, arg, err);
     }
 
     if (key == "src_ip" || key == "dst_ip") {
@@ -250,6 +263,29 @@ bool parse_effect(const std::string &eff, Rule &r, uint32_t nclk_mhz,
             return false;
         }
         r.eff_mask |= (key == "ecn") ? EFF_ECN : (key == "drop") ? EFF_DROP : EFF_COUNT;
+        return true;
+    }
+
+    if (key == "once") {
+        if (w.size() != 1) {
+            err = "'once' takes no argument";
+            return false;
+        }
+        r.shots = 1;
+        return true;
+    }
+
+    if (key == "shots") {
+        if (w.size() != 2) {
+            err = "'shots' needs a count, e.g. shots 6";
+            return false;
+        }
+        uint64_t v;
+        if (!parse_uint(w[1], v) || v == 0 || v > 0xFFFF) {
+            err = "shots '" + w[1] + "' is not a count between 1 and 65535";
+            return false;
+        }
+        r.shots = static_cast<uint32_t>(v);
         return true;
     }
 
@@ -319,12 +355,6 @@ ParseResult parse_rule(const std::string &line, Rule &out, std::string &err,
     return ParseResult::Ok;
 }
 
-void resolve_relative_psn(Rule &r, uint32_t initial_psn) {
-    if (!r.psn_relative) return;
-    r.psn_lo = r.psn_hi = (initial_psn + r.psn_offset) & 0xFFFFFF;
-    r.psn_relative = false;
-}
-
 std::vector<std::pair<uint32_t, uint64_t>> rule_to_csr_writes(const Rule &r, int slot) {
     std::vector<std::pair<uint32_t, uint64_t>> w;
 
@@ -333,6 +363,7 @@ std::vector<std::pair<uint32_t, uint64_t>> rule_to_csr_writes(const Rule &r, int
 
     w.emplace_back(rule_reg(slot, FLD_MATCH_PSN),
                    (r.psn_en ? (1ull << 56) : 0ull) |
+                   (r.psn_relative ? (1ull << 57) : 0ull) |
                    (static_cast<uint64_t>(r.psn_hi) << 32) | r.psn_lo);
 
     w.emplace_back(rule_reg(slot, FLD_MATCH_IP),
@@ -344,7 +375,8 @@ std::vector<std::pair<uint32_t, uint64_t>> rule_to_csr_writes(const Rule &r, int
                    (r.op_en  ? 4ull : 0ull) |
                    (static_cast<uint64_t>(r.opcode) << 8));
 
-    w.emplace_back(rule_reg(slot, FLD_EFFECT_MASK), r.eff_mask);
+    w.emplace_back(rule_reg(slot, FLD_EFFECT_MASK),
+                   (static_cast<uint64_t>(r.shots) << 16) | r.eff_mask);
     w.emplace_back(rule_reg(slot, FLD_EFFECT_PARAM), r.delay_cycles);
 
     w.emplace_back(rule_reg(slot, FLD_ENABLE), 1ull);
@@ -362,9 +394,10 @@ Rule rule_from_regs(const uint64_t reg[8], bool &enabled) {
     r.qpn_en = (reg[FLD_MATCH_QPN] >> 32) & 1ull;
     r.qpn    = static_cast<uint32_t>(reg[FLD_MATCH_QPN] & 0xFFFFFFull);
 
-    r.psn_en = (reg[FLD_MATCH_PSN] >> 56) & 1ull;
-    r.psn_lo = static_cast<uint32_t>(reg[FLD_MATCH_PSN] & 0xFFFFFFull);
-    r.psn_hi = static_cast<uint32_t>((reg[FLD_MATCH_PSN] >> 32) & 0xFFFFFFull);
+    r.psn_en       = (reg[FLD_MATCH_PSN] >> 56) & 1ull;
+    r.psn_relative = (reg[FLD_MATCH_PSN] >> 57) & 1ull;
+    r.psn_lo       = static_cast<uint32_t>(reg[FLD_MATCH_PSN] & 0xFFFFFFull);
+    r.psn_hi       = static_cast<uint32_t>((reg[FLD_MATCH_PSN] >> 32) & 0xFFFFFFull);
 
     r.ip_src = static_cast<uint32_t>(reg[FLD_MATCH_IP] & 0xFFFFFFFFull);
     r.ip_dst = static_cast<uint32_t>(reg[FLD_MATCH_IP] >> 32);
@@ -375,9 +408,10 @@ Rule rule_from_regs(const uint64_t reg[8], bool &enabled) {
     r.opcode = static_cast<uint8_t>((reg[FLD_MATCH_FLAGS] >> 8) & 0xFFull);
 
     r.eff_mask     = static_cast<uint8_t>(reg[FLD_EFFECT_MASK] & 0xFull);
+    r.shots        = static_cast<uint32_t>((reg[FLD_EFFECT_MASK] >> 16) & 0xFFFFull);
     r.delay_cycles = static_cast<uint32_t>(reg[FLD_EFFECT_PARAM] & 0xFFFFFFFFull);
 
-    r.psn_relative = false;
+    // Bit 57 says the bounds are offsets rather than absolute PSNs.
     return r;
 }
 
@@ -387,12 +421,11 @@ std::string rule_to_string(const Rule &r, uint32_t nclk_mhz) {
 
     if (r.qpn_en) conds.push_back("qpn " + std::to_string(r.qpn));
     if (r.psn_en) {
-        if (r.psn_relative) {
-            conds.push_back("psn +" + std::to_string(r.psn_offset));
-        } else if (r.psn_lo == r.psn_hi) {
-            conds.push_back("psn " + std::to_string(r.psn_lo));
+        const std::string rel = r.psn_relative ? "+" : "";
+        if (r.psn_lo == r.psn_hi) {
+            conds.push_back("psn " + rel + std::to_string(r.psn_lo));
         } else {
-            conds.push_back("psn " + std::to_string(r.psn_lo) + "-" +
+            conds.push_back("psn " + rel + std::to_string(r.psn_lo) + "-" +
                             std::to_string(r.psn_hi));
         }
     }
@@ -428,6 +461,8 @@ std::string rule_to_string(const Rule &r, uint32_t nclk_mhz) {
     }
     if (r.eff_mask & EFF_COUNT) effs.push_back("count");
     if (effs.empty()) effs.push_back("(none)");
+    if (r.shots == 1)      effs.push_back("once");
+    else if (r.shots != 0) effs.push_back("shots " + std::to_string(r.shots));
 
     for (size_t i = 0; i < effs.size(); i++) {
         os << effs[i];

--- a/examples/13_denim/sw/src/include/denim_regs.hpp
+++ b/examples/13_denim/sw/src/include/denim_regs.hpp
@@ -37,8 +37,10 @@
 namespace denim {
 
 // {major[15:0], minor[15:0]}. Must track DENIM_VERSION in denim_cnfg.sv.
-// 1.1 formalised register 6 and added SLV_CFG_PARTIAL at register 7 bit 1.
-constexpr uint32_t VERSION_EXPECTED = 0x0001'0001;
+// 1.1 formalised register 6 and added SLV_CFG_PARTIAL at register 7 bit 1
+// 1.2 added relative PSN
+// 1.3 added the per-rule shot limit and the armed bitmap
+constexpr uint32_t VERSION_EXPECTED = 0x0001'0003;
 
 constexpr int N_RULES     = 8;
 constexpr int N_GLOBAL    = 8;
@@ -62,6 +64,8 @@ enum GlobalReg : uint32_t {
 constexpr int DBG_BEATS_SHIFT     = 0;    // [23:0]  config beats applied
 constexpr int DBG_LAST_ADDR_SHIFT = 24;   // [31:24] address of the last beat
 constexpr int DBG_LAST_DATA_SHIFT = 32;   // [47:32] low 16 bits of its data
+constexpr int DBG_CAPTURED_SHIFT  = 48;   // [55:48] rules that captured a base PSN
+constexpr int DBG_ARMED_SHIFT     = 56;   // [63:56] rules that may still fire
 
 // CTRL bits
 constexpr uint64_t CTRL_GLOBAL_EN = 1ull << 0;
@@ -75,10 +79,10 @@ constexpr uint64_t SLV_CFG_PARTIAL = 1ull << 1;   // a sub-word write was seen
 enum RuleField : uint32_t {
     FLD_ENABLE       = 0,   // RW  [0] enable, written last so arming is atomic
     FLD_MATCH_QPN    = 1,   // RW  [23:0] qpn, [32] field enable
-    FLD_MATCH_PSN    = 2,   // RW  [23:0] lo, [55:32] hi, [56] field enable
+    FLD_MATCH_PSN    = 2,   // RW  [23:0] lo, [55:32] hi, [56] enable, [57] relative
     FLD_MATCH_IP     = 3,   // RW  {dst[63:32], src[31:0]}
     FLD_MATCH_FLAGS  = 4,   // RW  [0] src_en, [1] dst_en, [2] op_en, [15:8] opcode
-    FLD_EFFECT_MASK  = 5,   // RW  [3:0] {count, delay, drop, ecn}
+    FLD_EFFECT_MASK  = 5,   // RW  [3:0] {count, delay, drop, ecn}, [31:16] shots
     FLD_EFFECT_PARAM = 6,   // RW  [31:0] delay in nclk cycles
     FLD_COUNTERS     = 7,   // RO  {overflow[63:32], match[31:0]}
 };

--- a/examples/13_denim/sw/src/include/denim_regs.hpp
+++ b/examples/13_denim/sw/src/include/denim_regs.hpp
@@ -1,0 +1,96 @@
+/**
+ * This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+ *
+ * MIT Licence
+ * Copyright (c) 2026, Systems Group, ETH Zurich
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+/**
+ * DENIM register map.
+ *
+ * This mirrors hw/hdl/network/denim/denim_cnfg.sv exactly. The two are not
+ * generated from a common source, so DENIM_VERSION_EXPECTED is the guard.
+ */
+namespace denim {
+
+// {major[15:0], minor[15:0]}. Must track DENIM_VERSION in denim_cnfg.sv.
+// 1.1 formalised register 6 and added SLV_CFG_PARTIAL at register 7 bit 1.
+constexpr uint32_t VERSION_EXPECTED = 0x0001'0001;
+
+constexpr int N_RULES     = 8;
+constexpr int N_GLOBAL    = 8;
+constexpr int RULE_STRIDE = 8;
+constexpr int N_REGS      = N_GLOBAL + N_RULES * RULE_STRIDE;   // 72
+
+// Global registers
+enum GlobalReg : uint32_t {
+    REG_VERSION      = 0,   // RO  {major, minor}
+    REG_CTRL         = 1,   // RW  [0] GLOBAL_EN, [1] CTR_CLEAR (self clearing)
+    REG_PKT_COUNT    = 2,   // RO  {roce_pkts[63:32], all_pkts[31:0]}
+    REG_EFFECT_COUNT = 3,   // RO  {delay_overflows[63:32], drops[31:0]}
+    REG_ROCE_PORT    = 4,   // RW  [15:0] expected RoCE v2 UDP destination port
+    REG_ECN_COUNT    = 5,   // RO  [31:0] packets this build actually marked
+    REG_DEBUG        = 6,   // RO  config path observability, see DBG_* below
+    REG_SLV_STATUS   = 7,   // RO  slave local, see SLV_* below
+};
+
+// REG_DEBUG fields. What the datapath received, as opposed to what software
+// believes it sent.
+constexpr int DBG_BEATS_SHIFT     = 0;    // [23:0]  config beats applied
+constexpr int DBG_LAST_ADDR_SHIFT = 24;   // [31:24] address of the last beat
+constexpr int DBG_LAST_DATA_SHIFT = 32;   // [47:32] low 16 bits of its data
+
+// CTRL bits
+constexpr uint64_t CTRL_GLOBAL_EN = 1ull << 0;
+constexpr uint64_t CTRL_CTR_CLEAR = 1ull << 1;
+
+// REG_SLV_STATUS bits.
+constexpr uint64_t SLV_CFG_LOST    = 1ull << 0;   // a config write was dropped
+constexpr uint64_t SLV_CFG_PARTIAL = 1ull << 1;   // a sub-word write was seen
+
+// Per-rule field offsets from base 8 + 8i
+enum RuleField : uint32_t {
+    FLD_ENABLE       = 0,   // RW  [0] enable, written last so arming is atomic
+    FLD_MATCH_QPN    = 1,   // RW  [23:0] qpn, [32] field enable
+    FLD_MATCH_PSN    = 2,   // RW  [23:0] lo, [55:32] hi, [56] field enable
+    FLD_MATCH_IP     = 3,   // RW  {dst[63:32], src[31:0]}
+    FLD_MATCH_FLAGS  = 4,   // RW  [0] src_en, [1] dst_en, [2] op_en, [15:8] opcode
+    FLD_EFFECT_MASK  = 5,   // RW  [3:0] {count, delay, drop, ecn}
+    FLD_EFFECT_PARAM = 6,   // RW  [31:0] delay in nclk cycles
+    FLD_COUNTERS     = 7,   // RO  {overflow[63:32], match[31:0]}
+};
+
+// Effect mask bit positions, matching EFF_* in denim_pkg.sv
+constexpr uint8_t EFF_ECN   = 1u << 0;
+constexpr uint8_t EFF_DROP  = 1u << 1;
+constexpr uint8_t EFF_DELAY = 1u << 2;
+constexpr uint8_t EFF_COUNT = 1u << 3;
+
+constexpr uint32_t rule_reg(int slot, RuleField f) {
+    return static_cast<uint32_t>(N_GLOBAL + slot * RULE_STRIDE) + f;
+}
+
+} // namespace denim

--- a/examples/13_denim/sw/src/include/denim_rules.hpp
+++ b/examples/13_denim/sw/src/include/denim_rules.hpp
@@ -1,0 +1,122 @@
+/**
+ * This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+ *
+ * MIT Licence
+ * Copyright (c) 2026, Systems Group, ETH Zurich
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+/**
+ * DENIM rule grammar.
+ *
+ *     <condition>[, <condition>...] : <effect>[, <effect>...]
+ *
+ * Conditions are AND-ed and omitted fields are wildcards. The first matching
+ * rule wins and all of its effects apply.
+ *
+ *     qpn 3, psn 50-150   : delay 1us       # emulate queueing over a window
+ *     src_ip 10.1.212.62  : ecn             # fake congestion per sender
+ *     qpn 2, psn +100     : drop            # single loss at a relative PSN
+ *     qpn 2               : count           # monitor only
+ *     qpn 4, psn 0-500    : ecn, delay 2us  # two effects on one packet
+ *
+ * Conditions: qpn N | psn N | psn A-B | psn +K | src_ip a.b.c.d |
+ *             dst_ip a.b.c.d | opcode 0xNN
+ * Effects:    ecn | drop | delay <t>(ns|us) | count
+ */
+namespace denim {
+
+struct Rule {
+    bool     qpn_en = false;
+    uint32_t qpn    = 0;
+
+    bool     psn_en = false;
+    uint32_t psn_lo = 0;
+    uint32_t psn_hi = 0;
+
+    // psn +K is relative to the connection's initial PSN, which only exists at
+    // run time. Held here until resolved against rdma_service metadata, until
+    // then psn_lo and psn_hi are meaningless.
+    bool     psn_relative = false;
+    uint32_t psn_offset   = 0;
+
+    bool     src_en = false;
+    uint32_t ip_src = 0;
+    bool     dst_en = false;
+    uint32_t ip_dst = 0;
+
+    bool     op_en  = false;
+    uint8_t  opcode = 0;
+
+    uint8_t  eff_mask     = 0;
+    uint32_t delay_cycles = 0;
+};
+
+enum class ParseResult {
+    Ok,      // a rule was parsed
+    Skip,    // blank line or comment, not an error
+    Error,   // malformed, err holds the reason
+};
+
+/**
+ * Parse one line. nclk_mhz converts delay times into cycles and must match the
+ * NCLK_F the bitstream was built with, or every delay will be wrong by that
+ * ratio without anything reporting it.
+ */
+ParseResult parse_rule(const std::string &line, Rule &out, std::string &err,
+                       uint32_t nclk_mhz);
+
+/**
+ * Resolve a relative PSN once the connection's initial PSN is known.
+ */
+void resolve_relative_psn(Rule &r, uint32_t initial_psn);
+
+/**
+ * Register writes that install a rule into a slot, in order.
+ */
+std::vector<std::pair<uint32_t, uint64_t>> rule_to_csr_writes(const Rule &r, int slot);
+
+/**
+ * Writes that disarm a slot. A single ENABLE=0, leaving the fields intact so
+ * that a rule can be edited and re-armed without rewriting all of it.
+ */
+std::vector<std::pair<uint32_t, uint64_t>> rule_clear_writes(int slot);
+
+/**
+ * Rebuild a rule from the eight register values of one slot, indexed by
+ * RuleField. Used by --status, and the inverse of rule_to_csr_writes, so the
+ * two are round-trip tested against each other.
+ */
+Rule rule_from_regs(const uint64_t reg[8], bool &enabled);
+
+/**
+ * Render a rule back to grammar form, for --status output.
+ */
+std::string rule_to_string(const Rule &r, uint32_t nclk_mhz);
+
+} // namespace denim

--- a/examples/13_denim/sw/src/include/denim_rules.hpp
+++ b/examples/13_denim/sw/src/include/denim_rules.hpp
@@ -59,11 +59,9 @@ struct Rule {
     uint32_t psn_lo = 0;
     uint32_t psn_hi = 0;
 
-    // psn +K is relative to the connection's initial PSN, which only exists at
-    // run time. Held here until resolved against rdma_service metadata, until
-    // then psn_lo and psn_hi are meaningless.
+    // psn +K and psn +A-B are relative to the connection's initial PSN, which
+    // only exists at run time.
     bool     psn_relative = false;
-    uint32_t psn_offset   = 0;
 
     bool     src_en = false;
     uint32_t ip_src = 0;
@@ -75,6 +73,9 @@ struct Rule {
 
     uint8_t  eff_mask     = 0;
     uint32_t delay_cycles = 0;
+
+    // How many packets this rule may act on before it disarms itself
+    uint32_t shots        = 0;
 };
 
 enum class ParseResult {
@@ -94,7 +95,6 @@ ParseResult parse_rule(const std::string &line, Rule &out, std::string &err,
 /**
  * Resolve a relative PSN once the connection's initial PSN is known.
  */
-void resolve_relative_psn(Rule &r, uint32_t initial_psn);
 
 /**
  * Register writes that install a rule into a slot, in order.

--- a/examples/13_denim/sw/src/main.cpp
+++ b/examples/13_denim/sw/src/main.cpp
@@ -1,0 +1,407 @@
+/**
+ * This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+ *
+ * MIT Licence
+ * Copyright (c) 2026, Systems Group, ETH Zurich
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <boost/program_options.hpp>
+#include <coyote/cThread.hpp>
+
+#include "include/denim_regs.hpp"
+#include "include/denim_rules.hpp"
+
+using namespace denim;
+
+constexpr uint32_t DEF_DEVICE = 0;
+constexpr uint32_t DEF_VFID   = 0;
+constexpr uint32_t DEF_NCLK   = 250;   // must match the NCLK_F of the bitstream
+
+namespace {
+
+void write_regs(coyote::cThread &t,
+                const std::vector<std::pair<uint32_t, uint64_t>> &writes) {
+    // Note the argument order: setCSR takes the value first, the address
+    // second. Reversing them writes an address into a register.
+    for (const auto &w : writes) t.setCSR(w.second, w.first);
+}
+
+bool check_version(coyote::cThread &t) {
+    const uint32_t v     = static_cast<uint32_t>(t.getCSR(REG_VERSION));
+    const uint16_t major = v >> 16,          minor = v & 0xFFFF;
+    const uint16_t want_major = VERSION_EXPECTED >> 16,
+                   want_minor = VERSION_EXPECTED & 0xFFFF;
+
+    if (major != want_major) {
+        std::cerr << "denim_ctl: register map mismatch. Shell reports "
+                  << major << "." << minor << ", this build expects "
+                  << want_major << "." << want_minor << "\n"
+                  << "  Major versions differ, so the register map is not "
+                     "compatible. Rebuild one to match the other.\n";
+        return false;
+    }
+    if (minor != want_minor) {
+        std::cerr << "denim_ctl: shell is " << major << "." << minor
+                  << ", this build expects " << want_major << "." << want_minor
+                  << ". Continuing -- the map is compatible, but fields added "
+                     "after " << major << "." << minor << " read as zero.\n";
+    }
+    return true;
+}
+
+void set_global_en(coyote::cThread &t, bool on) {
+    const uint64_t ctrl = t.getCSR(REG_CTRL);
+    t.setCSR(on ? (ctrl | CTRL_GLOBAL_EN) : (ctrl & ~CTRL_GLOBAL_EN), REG_CTRL);
+}
+
+void clear_slot(coyote::cThread &t, int slot) {
+    write_regs(t, rule_clear_writes(slot));
+}
+
+/**
+ * Install a rule and confirm if it was successful.
+ */
+bool install_rule(coyote::cThread &t, int slot, const Rule &r, uint32_t nclk_mhz) {
+    clear_slot(t, slot);
+    write_regs(t, rule_to_csr_writes(r, slot));
+
+    uint64_t reg[RULE_STRIDE];
+    for (int f = 0; f < RULE_STRIDE; f++)
+        reg[f] = t.getCSR(rule_reg(slot, static_cast<RuleField>(f)));
+
+    bool enabled = false;
+    const Rule back = rule_from_regs(reg, enabled);
+    if (!enabled || rule_to_string(back, nclk_mhz) != rule_to_string(r, nclk_mhz)) {
+        std::cerr << "denim_ctl: slot " << slot << " did not take.\n"
+                  << "  wrote: " << rule_to_string(r, nclk_mhz) << "\n"
+                  << "  read:  " << (enabled ? rule_to_string(back, nclk_mhz)
+                                             : std::string("(disarmed)")) << "\n";
+        return false;
+    }
+    return true;
+}
+
+int load_file(coyote::cThread &t, const std::string &path, uint32_t nclk_mhz) {
+    std::ifstream in(path);
+    if (!in) {
+        std::cerr << "denim_ctl: cannot open " << path << "\n";
+        return 1;
+    }
+
+    std::vector<Rule> rules;
+    std::string line;
+    int lineno = 0;
+    while (std::getline(in, line)) {
+        lineno++;
+        Rule r;
+        std::string err;
+        switch (parse_rule(line, r, err, nclk_mhz)) {
+            case ParseResult::Skip:
+                continue;
+            case ParseResult::Error:
+                std::cerr << path << ":" << lineno << ": " << err << "\n";
+                return 1;
+            case ParseResult::Ok:
+                if (r.psn_relative) {
+                    std::cerr << path << ":" << lineno
+                              << ": relative PSN needs the connection's initial PSN, "
+                                 "which this tool cannot resolve yet\n";
+                    return 1;
+                }
+                rules.push_back(r);
+                break;
+        }
+    }
+
+    if (static_cast<int>(rules.size()) > N_RULES) {
+        std::cerr << path << ": " << rules.size() << " rules, but only " << N_RULES
+                  << " slots exist\n";
+        return 1;
+    }
+
+    // Drop GLOBAL_EN first so that no intermediate state goes live while the
+    // slots are rewritten, then re-enable once every slot is settled.
+    set_global_en(t, false);
+    for (int i = 0; i < N_RULES; i++) clear_slot(t, i);
+
+    for (size_t i = 0; i < rules.size(); i++) {
+        if (!install_rule(t, static_cast<int>(i), rules[i], nclk_mhz)) return 1;
+        std::cout << "slot " << i << ": " << rule_to_string(rules[i], nclk_mhz) << "\n";
+    }
+    set_global_en(t, true);
+
+    std::cout << rules.size() << " rule(s) installed, GLOBAL_EN set\n";
+    return 0;
+}
+
+void print_status(coyote::cThread &t, uint32_t nclk_mhz) {
+    const uint64_t ver   = t.getCSR(REG_VERSION);
+    const uint64_t ctrl  = t.getCSR(REG_CTRL);
+    const uint64_t pkts  = t.getCSR(REG_PKT_COUNT);
+    const uint64_t effs  = t.getCSR(REG_EFFECT_COUNT);
+    const uint64_t port  = t.getCSR(REG_ROCE_PORT);
+    const uint64_t ecn   = t.getCSR(REG_ECN_COUNT);
+    const uint64_t slv   = t.getCSR(REG_SLV_STATUS);
+
+    std::cout << "DENIM " << ((ver >> 16) & 0xFFFF) << "." << (ver & 0xFFFF)
+              << "   global_en=" << ((ctrl & CTRL_GLOBAL_EN) ? 1 : 0)
+              << "   roce_udp_port=0x" << std::hex << (port & 0xFFFF) << std::dec << "\n\n";
+
+    std::cout << "  packets seen      " << (pkts & 0xFFFFFFFF) << "\n"
+              << "  parsed as RoCE    " << (pkts >> 32) << "\n"
+              << "  marked ECN        " << (ecn & 0xFFFFFFFF) << "\n"
+              << "  dropped           " << (effs & 0xFFFFFFFF) << "\n"
+              << "  delay overflows   " << (effs >> 32) << "\n";
+
+    if (slv & SLV_CFG_LOST) {
+        std::cout << "\n  WARNING: a configuration write was lost; installed rules "
+                     "may not match what was asked for\n";
+    }
+    if (slv & SLV_CFG_PARTIAL) {
+        std::cout << "\n  WARNING: a sub-word configuration write was seen. A whole "
+                     "register crosses at a time, so it was forwarded with bytes "
+                     "the host did not write\n";
+    }
+
+    bool any_enabled = false;
+
+    std::cout << "\nslot  matched     overflow    rule\n";
+    for (int i = 0; i < N_RULES; i++) {
+        uint64_t reg[RULE_STRIDE];
+        for (int f = 0; f < RULE_STRIDE; f++)
+            reg[f] = t.getCSR(rule_reg(i, static_cast<RuleField>(f)));
+
+        bool enabled = false;
+        const Rule r = rule_from_regs(reg, enabled);
+        const uint64_t counters = reg[FLD_COUNTERS];
+        any_enabled |= enabled;
+
+        std::cout << std::setw(4) << i << "  " << std::setw(10)
+                  << (counters & 0xFFFFFFFF) << "  " << std::setw(10) << (counters >> 32)
+                  << "    " << (enabled ? rule_to_string(r, nclk_mhz)
+                                        : std::string("(empty)")) << "\n";
+    }
+
+    if (any_enabled && !(ctrl & CTRL_GLOBAL_EN)) {
+        std::cout << "\nNote: rules are installed but GLOBAL_EN is 0, so none of them "
+                     "can match. Arm with --global-en 1.\n";
+    }
+
+    if ((pkts >> 32) == 0 && (pkts & 0xFFFFFFFF) != 0) {
+        std::cout << "\nNote: packets are arriving but none parsed as RoCE v2. Check "
+                     "roce_udp_port against what the peer actually sends.\n";
+    }
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+    boost::program_options::options_description opts("denim_ctl options");
+    opts.add_options()
+        ("help,h", "this message")
+        ("device", boost::program_options::value<uint32_t>(), "Coyote device id")
+        ("vfpga", boost::program_options::value<uint32_t>(), "target vFPGA id")
+        ("nclk", boost::program_options::value<uint32_t>(),
+            "network clock in MHz, must match the bitstream's NCLK_F")
+        ("load", boost::program_options::value<std::string>(),
+            "install a rule file; line i goes to slot i, so file order is match priority")
+        ("slot", boost::program_options::value<int>(), "slot for --rule")
+        ("rule", boost::program_options::value<std::string>(),
+            "a single rule to install into --slot")
+        ("clear", boost::program_options::value<int>()->implicit_value(-1),
+            "disarm one slot, or every slot if given no argument")
+        ("global-en", boost::program_options::value<int>(),
+            "set GLOBAL_EN; 0 disarms every rule without erasing it")
+        ("clear-counters", "zero all counters")
+        ("roce-port", boost::program_options::value<std::string>(),
+            "override the expected RoCE v2 UDP destination port, e.g. 0x12b7")
+        ("status", "print counters and the installed rules")
+        ("peek", boost::program_options::value<int>(), "read one register by index")
+        ("poke", boost::program_options::value<std::string>(),
+            "write one register: --poke <index>=<value>, both accepting 0x")
+        ("scan", "write a probe value to every writable register and report which took")
+        ("debug", "decode the datapath observability register");
+
+    boost::program_options::variables_map args;
+    boost::program_options::store(
+        boost::program_options::parse_command_line(argc, argv, opts), args);
+    boost::program_options::notify(args);
+
+    if (args.count("help") || argc == 1) {
+        std::cout << opts << "\n";
+        return 0;
+    }
+
+    const uint32_t device   = args.count("device") ? args["device"].as<uint32_t>() : DEF_DEVICE;
+    const uint32_t vfid     = args.count("vfpga") ? args["vfpga"].as<uint32_t>() : DEF_VFID;
+    const uint32_t nclk_mhz = args.count("nclk") ? args["nclk"].as<uint32_t>() : DEF_NCLK;
+
+    coyote::cThread cthread(vfid, getpid(), device);
+
+    if (!check_version(cthread)) return 1;
+
+    if (args.count("roce-port")) {
+        const std::string s = args["roce-port"].as<std::string>();
+        const uint64_t p = std::stoull(s, nullptr, 0);
+        cthread.setCSR(p & 0xFFFF, REG_ROCE_PORT);
+        std::cout << "roce_udp_port set to 0x" << std::hex << (p & 0xFFFF) << std::dec << "\n";
+    }
+
+    if (args.count("clear")) {
+        const int slot = args["clear"].as<int>();
+        if (slot < 0) {
+            for (int i = 0; i < N_RULES; i++) clear_slot(cthread, i);
+            std::cout << "all slots disarmed\n";
+        } else if (slot >= N_RULES) {
+            std::cerr << "denim_ctl: slot " << slot << " does not exist, there are "
+                      << N_RULES << "\n";
+            return 1;
+        } else {
+            clear_slot(cthread, slot);
+            std::cout << "slot " << slot << " disarmed\n";
+        }
+    }
+
+    if (args.count("clear-counters")) {
+        const uint64_t ctrl = cthread.getCSR(REG_CTRL);
+        cthread.setCSR(ctrl | CTRL_CTR_CLEAR, REG_CTRL);
+        std::cout << "counters cleared\n";
+    }
+
+    if (args.count("load")) {
+        const int rc = load_file(cthread, args["load"].as<std::string>(), nclk_mhz);
+        if (rc) return rc;
+    }
+
+    if (args.count("rule")) {
+        if (!args.count("slot")) {
+            std::cerr << "denim_ctl: --rule needs --slot\n";
+            return 1;
+        }
+        const int slot = args["slot"].as<int>();
+        if (slot < 0 || slot >= N_RULES) {
+            std::cerr << "denim_ctl: slot " << slot << " does not exist, there are "
+                      << N_RULES << "\n";
+            return 1;
+        }
+
+        Rule r;
+        std::string err;
+        const auto res = parse_rule(args["rule"].as<std::string>(), r, err, nclk_mhz);
+        if (res != ParseResult::Ok) {
+            std::cerr << "denim_ctl: " << (err.empty() ? "not a rule" : err) << "\n";
+            return 1;
+        }
+        if (r.psn_relative) {
+            std::cerr << "denim_ctl: relative PSN needs the connection's initial PSN, "
+                         "which this tool cannot resolve yet\n";
+            return 1;
+        }
+        if (!install_rule(cthread, slot, r, nclk_mhz)) return 1;
+        std::cout << "slot " << slot << ": " << rule_to_string(r, nclk_mhz) << "\n";
+
+        // --load arms the table itself, this path is the incremental edit and
+        // deliberately leaves GLOBAL_EN alone, which after programming means
+        // off.
+        if (!(cthread.getCSR(REG_CTRL) & CTRL_GLOBAL_EN)) {
+            std::cout << "warning: GLOBAL_EN is 0, so no rule will match. "
+                         "Arm with --global-en 1\n";
+        }
+    }
+
+    if (args.count("global-en")) {
+        const bool on = args["global-en"].as<int>() != 0;
+        set_global_en(cthread, on);
+        std::cout << "GLOBAL_EN " << (on ? "set" : "cleared") << "\n";
+    }
+
+    if (args.count("peek")) {
+        const int r = args["peek"].as<int>();
+        std::cout << "reg " << r << " = 0x" << std::hex << std::setw(16)
+                  << std::setfill('0') << cthread.getCSR(r) << std::dec
+                  << std::setfill(' ') << "\n";
+    }
+
+    if (args.count("poke")) {
+        const std::string s = args["poke"].as<std::string>();
+        const auto eq = s.find('=');
+        if (eq == std::string::npos) {
+            std::cerr << "denim_ctl: --poke needs <index>=<value>\n";
+            return 1;
+        }
+        const uint32_t r = std::stoul(s.substr(0, eq), nullptr, 0);
+        const uint64_t v = std::stoull(s.substr(eq + 1), nullptr, 0);
+        cthread.setCSR(v, r);
+        std::cout << "reg " << r << " <- 0x" << std::hex << v << ", reads back 0x"
+                  << cthread.getCSR(r) << std::dec << "\n";
+    }
+
+    // Writes a distinct probe to every writable register and reports which
+    // ones held it. A register that reads back its probe is reachable, one
+    // that does not is either read only or not being decoded.
+    if (args.count("scan")) {
+        std::cout << "reg   wrote               read back           result\n";
+        int reachable = 0, dead = 0;
+        for (int r = 0; r < N_REGS; r++) {
+            const bool ro = (r == REG_VERSION || r == REG_PKT_COUNT ||
+                             r == REG_EFFECT_COUNT || r == REG_ECN_COUNT ||
+                             r == REG_SLV_STATUS ||
+                             (r >= N_GLOBAL && ((r - N_GLOBAL) % RULE_STRIDE) == FLD_COUNTERS));
+            if (ro) continue;
+
+            const uint64_t probe = 0xA5A50000ull | static_cast<uint64_t>(r);
+            const uint64_t before = cthread.getCSR(r);
+            cthread.setCSR(probe, r);
+            const uint64_t after = cthread.getCSR(r);
+            const bool took = (after == probe);
+            took ? reachable++ : dead++;
+            std::cout << std::setw(3) << r << "   0x" << std::hex << std::setw(16)
+                      << std::setfill('0') << probe << "  0x" << std::setw(16) << after
+                      << std::dec << std::setfill(' ') << "  " << (took ? "ok" : "NOT WRITTEN")
+                      << "\n";
+            cthread.setCSR(before, r);
+        }
+        std::cout << "\n" << reachable << " reachable, " << dead << " not written\n";
+        std::cout << "Registers restored to their previous values.\n";
+    }
+
+    // What the datapath received, as opposed to what software believes it sent.
+    if (args.count("debug")) {
+        const uint64_t d = cthread.getCSR(REG_DEBUG);
+        std::cout << "config beats applied : "
+                  << ((d >> DBG_BEATS_SHIFT) & 0xFFFFFF) << "\n"
+                  << "last address seen    : "
+                  << ((d >> DBG_LAST_ADDR_SHIFT) & 0xFF) << "\n"
+                  << "last data[15:0]      : 0x" << std::hex
+                  << ((d >> DBG_LAST_DATA_SHIFT) & 0xFFFF) << std::dec << "\n";
+    }
+
+    if (args.count("status")) print_status(cthread, nclk_mhz);
+
+    return 0;
+}

--- a/examples/13_denim/sw/src/main.cpp
+++ b/examples/13_denim/sw/src/main.cpp
@@ -24,6 +24,7 @@
  * SOFTWARE.
  */
 
+#include <algorithm>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -51,9 +52,12 @@ void write_regs(coyote::cThread &t,
     for (const auto &w : writes) t.setCSR(w.second, w.first);
 }
 
+uint16_t shell_minor = 0;
+
 bool check_version(coyote::cThread &t) {
     const uint32_t v     = static_cast<uint32_t>(t.getCSR(REG_VERSION));
     const uint16_t major = v >> 16,          minor = v & 0xFFFF;
+    shell_minor = minor;
     const uint16_t want_major = VERSION_EXPECTED >> 16,
                    want_minor = VERSION_EXPECTED & 0xFFFF;
 
@@ -87,6 +91,12 @@ void clear_slot(coyote::cThread &t, int slot) {
  * Install a rule and confirm if it was successful.
  */
 bool install_rule(coyote::cThread &t, int slot, const Rule &r, uint32_t nclk_mhz) {
+    if (r.shots != 0 && shell_minor < 3) {
+        std::cerr << "denim_ctl: this shell is 1." << shell_minor
+                  << " and has no shot limit, so 'once' and 'shots' cannot be "
+                     "honoured.\n";
+        return false;
+    }
     clear_slot(t, slot);
     write_regs(t, rule_to_csr_writes(r, slot));
 
@@ -127,12 +137,6 @@ int load_file(coyote::cThread &t, const std::string &path, uint32_t nclk_mhz) {
                 std::cerr << path << ":" << lineno << ": " << err << "\n";
                 return 1;
             case ParseResult::Ok:
-                if (r.psn_relative) {
-                    std::cerr << path << ":" << lineno
-                              << ": relative PSN needs the connection's initial PSN, "
-                                 "which this tool cannot resolve yet\n";
-                    return 1;
-                }
                 rules.push_back(r);
                 break;
         }
@@ -190,6 +194,13 @@ void print_status(coyote::cThread &t, uint32_t nclk_mhz) {
 
     bool any_enabled = false;
 
+    // Which relative rules have latched a base PSN.
+    const uint64_t dbg      = t.getCSR(REG_DEBUG);
+    const uint64_t captured = (dbg >> DBG_CAPTURED_SHIFT) & 0xFF;
+
+    // Which rules may still fire.
+    const uint64_t armed    = (dbg >> DBG_ARMED_SHIFT) & 0xFF;
+
     std::cout << "\nslot  matched     overflow    rule\n";
     for (int i = 0; i < N_RULES; i++) {
         uint64_t reg[RULE_STRIDE];
@@ -204,7 +215,17 @@ void print_status(coyote::cThread &t, uint32_t nclk_mhz) {
         std::cout << std::setw(4) << i << "  " << std::setw(10)
                   << (counters & 0xFFFFFFFF) << "  " << std::setw(10) << (counters >> 32)
                   << "    " << (enabled ? rule_to_string(r, nclk_mhz)
-                                        : std::string("(empty)")) << "\n";
+                                        : std::string("(empty)"))
+                  << (enabled && r.psn_relative
+                          ? ((captured >> i) & 1 ? "   [base captured]"
+                                                 : "   [waiting for first packet]")
+                          : "")
+                  << (enabled && r.shots != 0
+                          ? ((armed >> i) & 1
+                                 ? "   [" + std::to_string(r.shots - std::min<uint32_t>(r.shots, counters & 0xFFFFFFFF)) + " of " + std::to_string(r.shots) + " shots left]"
+                                 : std::string("   [spent]"))
+                          : std::string(""))
+                  << "\n";
     }
 
     if (any_enabled && !(ctrl & CTRL_GLOBAL_EN)) {
@@ -315,11 +336,6 @@ int main(int argc, char *argv[]) {
         const auto res = parse_rule(args["rule"].as<std::string>(), r, err, nclk_mhz);
         if (res != ParseResult::Ok) {
             std::cerr << "denim_ctl: " << (err.empty() ? "not a rule" : err) << "\n";
-            return 1;
-        }
-        if (r.psn_relative) {
-            std::cerr << "denim_ctl: relative PSN needs the connection's initial PSN, "
-                         "which this tool cannot resolve yet\n";
             return 1;
         }
         if (!install_rule(cthread, slot, r, nclk_mhz)) return 1;

--- a/hw/hdl/network/denim/denim_chain.sv
+++ b/hw/hdl/network/denim/denim_chain.sv
@@ -1,0 +1,184 @@
+/**
+ * This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+ *
+ * MIT Licence
+ * Copyright (c) 2021-2026, Systems Group, ETH Zurich
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+`timescale 1ns / 1ps
+
+import denim_pkg::*;
+
+/**
+ * @brief   DENIM effect chain
+ *
+ * filter -> drop -> ECN -> delay, plus the register file that configures them.
+ *
+ */
+module denim_chain #(
+    parameter integer           DATA_BITS  = 512,
+    parameter integer           FIFO_BEATS = 512,
+    parameter integer           PMTU_BYTES = 4096
+) (
+    /* Network stream, nclk domain */
+    input  logic [DATA_BITS-1:0]    s_axis_tdata,
+    input  logic [DATA_BITS/8-1:0]  s_axis_tkeep,
+    input  logic                    s_axis_tlast,
+    input  logic                    s_axis_tvalid,
+    output logic                    s_axis_tready,
+
+    output logic [DATA_BITS-1:0]    m_axis_tdata,
+    output logic [DATA_BITS/8-1:0]  m_axis_tkeep,
+    output logic                    m_axis_tlast,
+    output logic                    m_axis_tvalid,
+    input  logic                    m_axis_tready,
+
+    /* Config in, register mirror out */
+    input  logic [71:0]             s_cnfg_tdata,
+    input  logic                    s_cnfg_tvalid,
+    output logic                    s_cnfg_tready,
+
+    output logic [71:0]             m_stat_tdata,
+    output logic                    m_stat_tvalid,
+    input  logic                    m_stat_tready,
+
+    input  logic                    nclk,
+    input  logic                    nresetn
+);
+
+/**
+ * Configuration
+ */
+denim_rule_t rules [N_RULES];
+logic [31:0] delay_cycles [N_RULES];
+logic        global_en;
+logic [15:0] roce_port;
+logic        ctr_clear;
+
+logic [31:0] match_count [N_RULES];
+logic [31:0] all_pkts;
+logic [31:0] roce_pkts;
+logic [31:0] drop_count;
+logic [31:0] ecn_count;
+logic [31:0] ovf_count [N_RULES];
+logic [31:0] ovf_total;
+
+denim_cnfg inst_cnfg (
+    .s_cnfg_tdata   (s_cnfg_tdata),
+    .s_cnfg_tvalid  (s_cnfg_tvalid),
+    .s_cnfg_tready  (s_cnfg_tready),
+
+    .m_stat_tdata   (m_stat_tdata),
+    .m_stat_tvalid  (m_stat_tvalid),
+    .m_stat_tready  (m_stat_tready),
+
+    .rules          (rules),
+    .delay_cycles   (delay_cycles),
+    .global_en      (global_en),
+    .roce_port      (roce_port),
+    .ctr_clear      (ctr_clear),
+
+    .match_count    (match_count),
+    .all_pkts       (all_pkts),
+    .roce_pkts      (roce_pkts),
+    .drop_count     (drop_count),
+    .ecn_count      (ecn_count),
+    .ovf_count      (ovf_count),
+    .ovf_total      (ovf_total),
+
+    .nclk           (nclk),
+    .nresetn        (nresetn)
+);
+
+/**
+ * Datapath
+ */
+logic [DATA_BITS-1:0]   flt_tdata, drp_tdata, ecn_tdata;
+logic [DATA_BITS/8-1:0] flt_tkeep, drp_tkeep, ecn_tkeep;
+logic                   flt_tlast, drp_tlast, ecn_tlast;
+logic                   flt_tvalid, drp_tvalid, ecn_tvalid;
+logic                   flt_tready, drp_tready, ecn_tready;
+logic [TAG_BITS-1:0]    flt_tid, drp_tid, ecn_tid;
+
+denim_filter #(.DATA_BITS(DATA_BITS)) inst_filter (
+    .s_axis_tdata(s_axis_tdata), .s_axis_tkeep(s_axis_tkeep),
+    .s_axis_tlast(s_axis_tlast), .s_axis_tvalid(s_axis_tvalid),
+    .s_axis_tready(s_axis_tready),
+
+    .m_axis_tdata(flt_tdata), .m_axis_tkeep(flt_tkeep),
+    .m_axis_tlast(flt_tlast), .m_axis_tvalid(flt_tvalid),
+    .m_axis_tready(flt_tready), .m_axis_tid(flt_tid),
+
+    .rules(rules), .global_en(global_en), .roce_port(roce_port),
+    .match_count(match_count), .all_pkts(all_pkts), .roce_pkts(roce_pkts),
+    .ctr_clear(ctr_clear),
+
+    .nclk(nclk), .nresetn(nresetn)
+);
+
+denim_drop #(.DATA_BITS(DATA_BITS)) inst_drop (
+    .s_axis_tdata(flt_tdata), .s_axis_tkeep(flt_tkeep),
+    .s_axis_tlast(flt_tlast), .s_axis_tvalid(flt_tvalid),
+    .s_axis_tready(flt_tready), .s_axis_tid(flt_tid),
+
+    .m_axis_tdata(drp_tdata), .m_axis_tkeep(drp_tkeep),
+    .m_axis_tlast(drp_tlast), .m_axis_tvalid(drp_tvalid),
+    .m_axis_tready(drp_tready), .m_axis_tid(drp_tid),
+
+    .drop_count(drop_count), .ctr_clear(ctr_clear),
+
+    .nclk(nclk), .nresetn(nresetn)
+);
+
+denim_ecn #(.DATA_BITS(DATA_BITS)) inst_ecn (
+    .s_axis_tdata(drp_tdata), .s_axis_tkeep(drp_tkeep),
+    .s_axis_tlast(drp_tlast), .s_axis_tvalid(drp_tvalid),
+    .s_axis_tready(drp_tready), .s_axis_tid(drp_tid),
+
+    .m_axis_tdata(ecn_tdata), .m_axis_tkeep(ecn_tkeep),
+    .m_axis_tlast(ecn_tlast), .m_axis_tvalid(ecn_tvalid),
+    .m_axis_tready(ecn_tready), .m_axis_tid(ecn_tid),
+
+    .ecn_count(ecn_count), .ctr_clear(ctr_clear),
+
+    .nclk(nclk), .nresetn(nresetn)
+);
+
+// The tag ends here. Downstream is the IP handler, which knows nothing about DENIM and must see an ordinary AXI4-Stream.
+denim_delay #(
+    .DATA_BITS(DATA_BITS), .FIFO_BEATS(FIFO_BEATS), .PMTU_BYTES(PMTU_BYTES)
+) inst_delay (
+    .s_axis_tdata(ecn_tdata), .s_axis_tkeep(ecn_tkeep),
+    .s_axis_tlast(ecn_tlast), .s_axis_tvalid(ecn_tvalid),
+    .s_axis_tready(ecn_tready), .s_axis_tid(ecn_tid),
+
+    .m_axis_tdata(m_axis_tdata), .m_axis_tkeep(m_axis_tkeep),
+    .m_axis_tlast(m_axis_tlast), .m_axis_tvalid(m_axis_tvalid),
+    .m_axis_tready(m_axis_tready), .m_axis_tid(),
+
+    .delay_cycles(delay_cycles),
+    .ovf_count(ovf_count), .ovf_total(ovf_total), .ctr_clear(ctr_clear),
+
+    .nclk(nclk), .nresetn(nresetn)
+);
+
+endmodule

--- a/hw/hdl/network/denim/denim_chain.sv
+++ b/hw/hdl/network/denim/denim_chain.sv
@@ -37,6 +37,7 @@ import denim_pkg::*;
 module denim_chain #(
     parameter integer           DATA_BITS  = 512,
     parameter integer           FIFO_BEATS = 512,
+    parameter integer           META_ENTRIES = 512,
     parameter integer           PMTU_BYTES = 4096
 ) (
     /* Network stream, nclk domain */
@@ -81,6 +82,8 @@ logic [31:0] drop_count;
 logic [31:0] ecn_count;
 logic [31:0] ovf_count [N_RULES];
 logic [31:0] ovf_total;
+logic [N_RULES-1:0] psn_captured;
+logic [N_RULES-1:0] rule_armed;
 
 denim_cnfg inst_cnfg (
     .s_cnfg_tdata   (s_cnfg_tdata),
@@ -104,6 +107,8 @@ denim_cnfg inst_cnfg (
     .ecn_count      (ecn_count),
     .ovf_count      (ovf_count),
     .ovf_total      (ovf_total),
+    .psn_captured   (psn_captured),
+    .rule_armed     (rule_armed),
 
     .nclk           (nclk),
     .nresetn        (nresetn)
@@ -117,7 +122,8 @@ logic [DATA_BITS/8-1:0] flt_tkeep, drp_tkeep, ecn_tkeep;
 logic                   flt_tlast, drp_tlast, ecn_tlast;
 logic                   flt_tvalid, drp_tvalid, ecn_tvalid;
 logic                   flt_tready, drp_tready, ecn_tready;
-logic [TAG_BITS-1:0]    flt_tid, drp_tid, ecn_tid;
+
+(* max_fanout = 16 *) logic [TAG_BITS-1:0] flt_tid, drp_tid, ecn_tid;
 
 denim_filter #(.DATA_BITS(DATA_BITS)) inst_filter (
     .s_axis_tdata(s_axis_tdata), .s_axis_tkeep(s_axis_tkeep),
@@ -130,6 +136,7 @@ denim_filter #(.DATA_BITS(DATA_BITS)) inst_filter (
 
     .rules(rules), .global_en(global_en), .roce_port(roce_port),
     .match_count(match_count), .all_pkts(all_pkts), .roce_pkts(roce_pkts),
+    .psn_captured(psn_captured), .rule_armed(rule_armed),
     .ctr_clear(ctr_clear),
 
     .nclk(nclk), .nresetn(nresetn)
@@ -165,7 +172,8 @@ denim_ecn #(.DATA_BITS(DATA_BITS)) inst_ecn (
 
 // The tag ends here. Downstream is the IP handler, which knows nothing about DENIM and must see an ordinary AXI4-Stream.
 denim_delay #(
-    .DATA_BITS(DATA_BITS), .FIFO_BEATS(FIFO_BEATS), .PMTU_BYTES(PMTU_BYTES)
+    .DATA_BITS(DATA_BITS), .FIFO_BEATS(FIFO_BEATS),
+    .META_ENTRIES(META_ENTRIES), .PMTU_BYTES(PMTU_BYTES)
 ) inst_delay (
     .s_axis_tdata(ecn_tdata), .s_axis_tkeep(ecn_tkeep),
     .s_axis_tlast(ecn_tlast), .s_axis_tvalid(ecn_tvalid),

--- a/hw/hdl/network/denim/denim_cnfg.sv
+++ b/hw/hdl/network/denim/denim_cnfg.sv
@@ -1,0 +1,258 @@
+/**
+ * This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+ *
+ * MIT Licence
+ * Copyright (c) 2021-2026, Systems Group, ETH Zurich
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+`timescale 1ns / 1ps
+
+import denim_pkg::*;
+
+/**
+ * @brief   DENIM configuration and counter transport
+ *
+ * Owns the register file. Configuration arrives as {addr, data} beats from the
+ * control vFPGA and counters are streamed back the same way, both crossing the
+ * clock domain outside this module in denim_top.
+ *
+ */
+module denim_cnfg (
+    /* Config in: {addr[7:0], data[63:0]} */
+    input  logic [71:0]         s_cnfg_tdata,
+    input  logic                s_cnfg_tvalid,
+    output logic                s_cnfg_tready,
+
+    /* Register mirror out: {reg_id[7:0], value[63:0]} */
+    output logic [71:0]         m_stat_tdata,
+    output logic                m_stat_tvalid,
+    input  logic                m_stat_tready,
+
+    /* Decoded configuration */
+    output denim_rule_t         rules [N_RULES],
+    output logic [31:0]         delay_cycles [N_RULES],
+    output logic                global_en,
+    output logic [15:0]         roce_port,
+    output logic                ctr_clear,
+
+    /* Live counters */
+    input  logic [31:0]         match_count [N_RULES],
+    input  logic [31:0]         all_pkts,
+    input  logic [31:0]         roce_pkts,
+    input  logic [31:0]         drop_count,
+    input  logic [31:0]         ecn_count,
+    input  logic [31:0]         ovf_count [N_RULES],
+    input  logic [31:0]         ovf_total,
+
+    input  logic                nclk,
+    input  logic                nresetn
+);
+
+// Bump on any change to the register map. denim_ctl refuses to run on a mismatch.
+// {major[15:0], minor[15:0]} 
+localparam logic [31:0] DENIM_VERSION = 32'h0001_0001;
+
+localparam integer N_GLOBAL   = 8;
+localparam integer RULE_STRIDE = 8;
+localparam integer N_REGS     = N_GLOBAL + N_RULES * RULE_STRIDE;   // 72
+
+// Global register indices
+localparam integer REG_VERSION   = 0;
+localparam integer REG_CTRL      = 1;
+localparam integer REG_PKT_COUNT = 2;
+localparam integer REG_EFF_COUNT = 3;
+localparam integer REG_ROCE_PORT = 4;
+localparam integer REG_ECN_COUNT = 5;
+localparam integer REG_DEBUG     = 6;
+
+// Per-rule field offsets from base 8 + 8i
+localparam integer FLD_ENABLE      = 0;
+localparam integer FLD_MATCH_QPN   = 1;
+localparam integer FLD_MATCH_PSN   = 2;
+localparam integer FLD_MATCH_IP    = 3;
+localparam integer FLD_MATCH_FLAGS = 4;
+localparam integer FLD_EFFECT_MASK = 5;
+localparam integer FLD_EFFECT_PARM = 6;
+localparam integer FLD_COUNTERS    = 7;     // read only, not stored
+
+/**
+ * Write path
+ */
+logic [7:0]  cnfg_addr;
+logic [63:0] cnfg_data;
+logic        cnfg_fire;
+
+assign s_cnfg_tready = 1'b1;                // a config write is never refused
+assign cnfg_addr     = s_cnfg_tdata[71:64];
+assign cnfg_data     = s_cnfg_tdata[63:0];
+assign cnfg_fire     = s_cnfg_tvalid & s_cnfg_tready;
+
+// Only the writable registers are stored. Offset 7 of each slot is a counter
+// pair and offsets 6 and 7 of the global block are unused, so neither is here.
+logic [63:0] rule_reg [N_RULES][RULE_STRIDE-1];
+logic [63:0] ctrl_reg;
+logic [15:0] port_reg;
+
+logic is_global;
+
+assign is_global = (cnfg_addr < N_GLOBAL);
+
+// Each rule register decodes its own address and carries its own enable.
+generate
+    for (genvar gr = 0; gr < N_RULES; gr++) begin : g_rule
+        for (genvar gf = 0; gf < RULE_STRIDE-1; gf++) begin : g_field
+            always_ff @(posedge nclk) begin
+                if (~nresetn) begin
+                    rule_reg[gr][gf] <= '0;
+                end else if (cnfg_fire && !is_global &&
+                             cnfg_addr == 8'(N_GLOBAL + gr*RULE_STRIDE + gf)) begin
+                    rule_reg[gr][gf] <= cnfg_data;
+                end
+            end
+        end
+    end
+endgenerate
+
+always_ff @(posedge nclk) begin
+    if (~nresetn) begin
+        ctrl_reg  <= '0;
+        port_reg  <= ROCE_UDP_PORT;
+        ctr_clear <= 1'b0;
+    end else begin
+        ctr_clear <= 1'b0;
+
+        if (cnfg_fire) begin
+            if (is_global) begin
+                case (cnfg_addr[2:0])
+                    REG_CTRL[2:0]: begin
+                        ctrl_reg  <= {cnfg_data[63:2], 1'b0, cnfg_data[0]};
+                        ctr_clear <= cnfg_data[1];
+                    end
+                    REG_ROCE_PORT[2:0]:
+                        port_reg <= cnfg_data[15:0];
+                    default: ;         // VERSION and the counters are read only
+                endcase
+            end
+            // Rule registers are written by the generate block above
+        end
+    end
+end
+
+/**
+ * Decode
+ */
+// Layout mirrored exactly by the enum in denim_ctl.
+always_comb begin
+    global_en = ctrl_reg[0];
+    roce_port = port_reg;
+
+    for (int r = 0; r < N_RULES; r++) begin
+        rules[r].en        = rule_reg[r][FLD_ENABLE][0];
+
+        rules[r].qpn       = rule_reg[r][FLD_MATCH_QPN][23:0];
+        rules[r].qpn_en    = rule_reg[r][FLD_MATCH_QPN][32];
+
+        rules[r].psn_lo    = rule_reg[r][FLD_MATCH_PSN][23:0];
+        rules[r].psn_hi    = rule_reg[r][FLD_MATCH_PSN][55:32];
+        rules[r].psn_en    = rule_reg[r][FLD_MATCH_PSN][56];
+
+        rules[r].ip_src    = rule_reg[r][FLD_MATCH_IP][31:0];
+        rules[r].ip_dst    = rule_reg[r][FLD_MATCH_IP][63:32];
+
+        rules[r].src_en    = rule_reg[r][FLD_MATCH_FLAGS][0];
+        rules[r].dst_en    = rule_reg[r][FLD_MATCH_FLAGS][1];
+        rules[r].op_en     = rule_reg[r][FLD_MATCH_FLAGS][2];
+        rules[r].opcode    = rule_reg[r][FLD_MATCH_FLAGS][15:8];
+
+        rules[r].eff_mask  = rule_reg[r][FLD_EFFECT_MASK][3:0];
+        rules[r].eff_param = rule_reg[r][FLD_EFFECT_PARM][31:0];
+
+        delay_cycles[r]    = rule_reg[r][FLD_EFFECT_PARM][31:0];
+    end
+end
+
+/**
+ * Observability
+ */
+// Config-path observability, at global register 6. This reports what the
+// datapath actually received, as opposed to what software believes it sent.
+logic [23:0] dbg_beats;
+logic [7:0]  dbg_last_addr;
+logic [15:0] dbg_last_data;
+
+always_ff @(posedge nclk) begin
+    if (~nresetn) begin
+        dbg_beats     <= '0;
+        dbg_last_addr <= '0;
+        dbg_last_data <= '0;
+    end else if (cnfg_fire) begin
+        dbg_beats     <= dbg_beats + 24'd1;
+        dbg_last_addr <= cnfg_addr;
+        dbg_last_data <= cnfg_data[15:0];
+    end
+end
+
+/**
+ * Register mirror
+ */
+logic [7:0]  stat_idx;
+logic [63:0] stat_val;
+logic [2:0]  stat_rule;
+logic [2:0]  stat_fld;
+logic [5:0]  stat_off;
+
+assign stat_off  = stat_idx[5:0] - N_GLOBAL[5:0];
+assign stat_rule = stat_off[5:3];
+assign stat_fld  = stat_off[2:0];
+
+always_comb begin
+    if (stat_idx < N_GLOBAL) begin
+        case (stat_idx[2:0])
+            REG_VERSION[2:0]:   stat_val = {32'd0, DENIM_VERSION};
+            REG_CTRL[2:0]:      stat_val = ctrl_reg;
+            REG_PKT_COUNT[2:0]: stat_val = {roce_pkts, all_pkts};
+            REG_EFF_COUNT[2:0]: stat_val = {ovf_total, drop_count};
+            REG_ROCE_PORT[2:0]: stat_val = {48'd0, port_reg};
+            REG_ECN_COUNT[2:0]: stat_val = {32'd0, ecn_count};
+            REG_DEBUG[2:0]:     stat_val = {16'd0, dbg_last_data,
+                                            dbg_last_addr, dbg_beats};
+            default:            stat_val = '0;
+        endcase
+    end else if (stat_fld == FLD_COUNTERS[2:0]) begin
+        stat_val = {ovf_count[stat_rule], match_count[stat_rule]};
+    end else begin
+        stat_val = rule_reg[stat_rule][stat_fld];
+    end
+end
+
+always_ff @(posedge nclk) begin
+    if (~nresetn) begin
+        stat_idx <= '0;
+    end else if (m_stat_tvalid & m_stat_tready) begin
+        stat_idx <= (stat_idx == N_REGS[7:0] - 8'd1) ? 8'd0 : stat_idx + 8'd1;
+    end
+end
+
+assign m_stat_tvalid = 1'b1;
+assign m_stat_tdata  = {stat_idx, stat_val};
+
+endmodule

--- a/hw/hdl/network/denim/denim_cnfg.sv
+++ b/hw/hdl/network/denim/denim_cnfg.sv
@@ -62,6 +62,8 @@ module denim_cnfg (
     input  logic [31:0]         ecn_count,
     input  logic [31:0]         ovf_count [N_RULES],
     input  logic [31:0]         ovf_total,
+    input  logic [N_RULES-1:0]  psn_captured,
+    input  logic [N_RULES-1:0]  rule_armed,
 
     input  logic                nclk,
     input  logic                nresetn
@@ -69,7 +71,7 @@ module denim_cnfg (
 
 // Bump on any change to the register map. denim_ctl refuses to run on a mismatch.
 // {major[15:0], minor[15:0]} 
-localparam logic [31:0] DENIM_VERSION = 32'h0001_0001;
+localparam logic [31:0] DENIM_VERSION = 32'h0001_0003;
 
 localparam integer N_GLOBAL   = 8;
 localparam integer RULE_STRIDE = 8;
@@ -174,6 +176,7 @@ always_comb begin
         rules[r].psn_lo    = rule_reg[r][FLD_MATCH_PSN][23:0];
         rules[r].psn_hi    = rule_reg[r][FLD_MATCH_PSN][55:32];
         rules[r].psn_en    = rule_reg[r][FLD_MATCH_PSN][56];
+        rules[r].psn_rel   = rule_reg[r][FLD_MATCH_PSN][57];
 
         rules[r].ip_src    = rule_reg[r][FLD_MATCH_IP][31:0];
         rules[r].ip_dst    = rule_reg[r][FLD_MATCH_IP][63:32];
@@ -184,6 +187,9 @@ always_comb begin
         rules[r].opcode    = rule_reg[r][FLD_MATCH_FLAGS][15:8];
 
         rules[r].eff_mask  = rule_reg[r][FLD_EFFECT_MASK][3:0];
+        // Spare bits of the same register, so a shot limit needs no new
+        // address and the stride stays at eight.
+        rules[r].shots     = rule_reg[r][FLD_EFFECT_MASK][31:16];
         rules[r].eff_param = rule_reg[r][FLD_EFFECT_PARM][31:0];
 
         delay_cycles[r]    = rule_reg[r][FLD_EFFECT_PARM][31:0];
@@ -233,8 +239,9 @@ always_comb begin
             REG_EFF_COUNT[2:0]: stat_val = {ovf_total, drop_count};
             REG_ROCE_PORT[2:0]: stat_val = {48'd0, port_reg};
             REG_ECN_COUNT[2:0]: stat_val = {32'd0, ecn_count};
-            REG_DEBUG[2:0]:     stat_val = {16'd0, dbg_last_data,
-                                            dbg_last_addr, dbg_beats};
+            REG_DEBUG[2:0]:     stat_val = {rule_armed, psn_captured,
+                                            dbg_last_data, dbg_last_addr,
+                                            dbg_beats};
             default:            stat_val = '0;
         endcase
     end else if (stat_fld == FLD_COUNTERS[2:0]) begin

--- a/hw/hdl/network/denim/denim_delay.sv
+++ b/hw/hdl/network/denim/denim_delay.sv
@@ -118,13 +118,21 @@ logic pkt_start;
 logic pkt_first;
 logic admit;
 logic reject_this;
-logic wr_fire;
+
+(* max_fanout = 8 *) logic wr_fire;
 
 assign pkt_start   = ~in_pkt_not_first & s_axis_tvalid;
 assign pkt_first   = pkt_start & s_axis_tready;
 
-assign admit       = ((FIFO_BEATS - occupancy) >= MAX_PKT_BEATS) &&
-                     (meta_occ < META_ENTRIES);
+always_ff @(posedge nclk) begin
+    if (~nresetn) begin
+        admit <= 1'b1;
+    end else begin
+        admit <= ((FIFO_BEATS - occupancy) > MAX_PKT_BEATS) &&
+                 (meta_occ < (META_ENTRIES - 1));
+    end
+end
+
 assign reject_this = pkt_start ? ~admit : rejecting_r;
 assign wr_fire     = s_axis_tvalid & s_axis_tready & ~reject_this;
 

--- a/hw/hdl/network/denim/denim_delay.sv
+++ b/hw/hdl/network/denim/denim_delay.sv
@@ -1,0 +1,259 @@
+/**
+ * This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+ *
+ * MIT Licence
+ * Copyright (c) 2021-2026, Systems Group, ETH Zurich
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+`timescale 1ns / 1ps
+
+import denim_pkg::*;
+
+/**
+ * @brief   DENIM delay effect
+ *
+ * Holds a tagged packet until a per-rule number of nclk cycles has elapsed,
+ * emulating the queueing delay a congested switch would add.
+ */
+module denim_delay #(
+    parameter integer           DATA_BITS  = 512,
+    parameter integer           FIFO_BEATS = 512,
+    // Packets in flight, which is a separate bound from beats in flight.
+    parameter integer           META_ENTRIES = 512,
+    parameter integer           PMTU_BYTES = 4096,
+    parameter logic [31:0]      TIME_INIT  = 32'd0
+) (
+    /* Network stream in, carrying the filter's verdict tag */
+    input  logic [DATA_BITS-1:0]    s_axis_tdata,
+    input  logic [DATA_BITS/8-1:0]  s_axis_tkeep,
+    input  logic                    s_axis_tlast,
+    input  logic                    s_axis_tvalid,
+    output logic                    s_axis_tready,
+    input  logic [TAG_BITS-1:0]     s_axis_tid,
+
+    /* Network stream out */
+    output logic [DATA_BITS-1:0]    m_axis_tdata,
+    output logic [DATA_BITS/8-1:0]  m_axis_tkeep,
+    output logic                    m_axis_tlast,
+    output logic                    m_axis_tvalid,
+    input  logic                    m_axis_tready,
+    output logic [TAG_BITS-1:0]     m_axis_tid,
+
+    /* Per-rule delay, in nclk cycles */
+    input  logic [31:0]             delay_cycles [N_RULES],
+
+    /* Counters */
+    output logic [31:0]             ovf_count [N_RULES],
+    output logic [31:0]             ovf_total,
+    input  logic                    ctr_clear,
+
+    input  logic                    nclk,
+    input  logic                    nresetn
+);
+
+localparam integer PTR_BITS      = $clog2(FIFO_BEATS);
+localparam integer META_PTR_BITS = $clog2(META_ENTRIES);
+localparam integer KEEP_BITS     = DATA_BITS/8;
+localparam integer WORD_BITS     = TAG_BITS + 1 + KEEP_BITS + DATA_BITS;
+
+// Packet length is unknown on the first beat, so admission reserves room for
+// the largest frame the build can produce. 
+localparam integer MAX_PKT_BEATS = (PMTU_BYTES + 128 + 63) / 64;
+
+/**
+ * Storage
+ */
+logic [WORD_BITS-1:0] mem [FIFO_BEATS];
+logic [WORD_BITS-1:0] mem_q;
+
+logic                 last_mem [FIFO_BEATS];
+
+logic [31:0]              rel_mem [META_ENTRIES];
+
+logic [PTR_BITS:0]        wr_ptr;
+logic [PTR_BITS:0]        rd_ptr;
+logic [META_PTR_BITS:0]   meta_wr;
+logic [META_PTR_BITS:0]   meta_rd;
+logic [PTR_BITS:0]        occupancy;
+logic [META_PTR_BITS:0]   meta_occ;
+
+assign occupancy = wr_ptr - rd_ptr;
+assign meta_occ  = meta_wr - meta_rd;
+
+/**
+ * Free-running timebase
+ */
+logic [31:0] now;
+
+always_ff @(posedge nclk) begin
+    if (~nresetn) now <= TIME_INIT;
+    else          now <= now + 32'd1;
+end
+
+/**
+ * Ingress
+ */
+logic in_pkt_not_first;
+logic rejecting_r;
+logic pkt_start;
+logic pkt_first;
+logic admit;
+logic reject_this;
+logic wr_fire;
+
+assign pkt_start   = ~in_pkt_not_first & s_axis_tvalid;
+assign pkt_first   = pkt_start & s_axis_tready;
+
+assign admit       = ((FIFO_BEATS - occupancy) >= MAX_PKT_BEATS) &&
+                     (meta_occ < META_ENTRIES);
+assign reject_this = pkt_start ? ~admit : rejecting_r;
+assign wr_fire     = s_axis_tvalid & s_axis_tready & ~reject_this;
+
+// The delay is looked up with the tag's rule id, so two rules can hold their
+// packets for different times. An untagged packet, or one whose rule did not
+// ask for delay, is released as soon as it reaches the head.
+logic [31:0] rel_pre [N_RULES];
+logic [31:0] rel_time;
+logic        want_delay;
+
+always_ff @(posedge nclk) begin
+    if (~nresetn) begin
+        for (int i = 0; i < N_RULES; i++) rel_pre[i] <= TIME_INIT;
+    end else begin
+        // Plus one, because these are registered and therefore consumed on the
+        // cycle after they are computed, by which time now has advanced. The
+        // result is that rel_pre[i] always reads as now + delay_cycles[i].
+        for (int i = 0; i < N_RULES; i++)
+            rel_pre[i] <= now + delay_cycles[i] + 32'd1;
+    end
+end
+
+assign want_delay = s_axis_tid[TAG_VALID_BIT] & s_axis_tid[TAG_MASK_LSB + EFF_DELAY];
+
+assign rel_time = want_delay ? rel_pre[s_axis_tid[TAG_ID_LSB +: RULE_ID_BITS]]
+                             : now;
+
+always_ff @(posedge nclk) begin
+    if (~nresetn) begin
+        in_pkt_not_first <= 1'b0;
+        rejecting_r      <= 1'b0;
+        wr_ptr           <= '0;
+        meta_wr          <= '0;
+    end else begin
+        if (s_axis_tvalid & s_axis_tready) begin
+            in_pkt_not_first <= ~s_axis_tlast;
+            rejecting_r      <= s_axis_tlast ? 1'b0 : reject_this;
+        end
+
+        if (wr_fire) begin
+            mem[wr_ptr[PTR_BITS-1:0]]      <= {s_axis_tid, s_axis_tlast, s_axis_tkeep, s_axis_tdata};
+            last_mem[wr_ptr[PTR_BITS-1:0]] <= s_axis_tlast;
+            wr_ptr                         <= wr_ptr + 1'b1;
+        end
+
+        if (pkt_first & ~reject_this) begin
+            rel_mem[meta_wr[META_PTR_BITS-1:0]] <= rel_time;
+            meta_wr                        <= meta_wr + 1'b1;
+        end
+    end
+end
+
+/**
+ * Egress
+ */
+logic                 s1_valid;
+logic                 s2_valid;
+logic [WORD_BITS-1:0] out_word;
+logic                 fifo_ne;
+logic                 rd_is_last;
+logic                 head_due;
+logic                 do_read;
+logic                 s1_to_s2;
+logic                 m_accept;
+
+assign fifo_ne    = (rd_ptr != wr_ptr);
+assign rd_is_last = last_mem[rd_ptr[PTR_BITS-1:0]];
+assign m_accept   = m_axis_tvalid & m_axis_tready;
+
+assign head_due   = (meta_rd != meta_wr) &&
+                    ($signed(now - rel_mem[meta_rd[META_PTR_BITS-1:0]]) >= 0);
+
+assign s1_to_s2 = s1_valid & (~s2_valid | m_accept);
+assign do_read  = fifo_ne & head_due & (~s1_valid | s1_to_s2);
+
+always_ff @(posedge nclk) begin
+    if (~nresetn) begin
+        rd_ptr   <= '0;
+        meta_rd  <= '0;
+        s1_valid <= 1'b0;
+        s2_valid <= 1'b0;
+    end else begin
+        if (do_read) begin
+            mem_q  <= mem[rd_ptr[PTR_BITS-1:0]];
+            rd_ptr <= rd_ptr + 1'b1;
+            if (rd_is_last) meta_rd <= meta_rd + 1'b1;
+        end
+
+        if (s1_to_s2) out_word <= mem_q;
+
+        if (do_read)        s1_valid <= 1'b1;
+        else if (s1_to_s2)  s1_valid <= 1'b0;
+
+        if (s1_to_s2)       s2_valid <= 1'b1;
+        else if (m_accept)  s2_valid <= 1'b0;
+    end
+end
+
+/**
+ * Counters
+ */
+// A rejected packet always bumps the total. It bumps a rule's counter only if
+// it carried a valid tag: a packet rejected because someone else's delayed
+// packet filled the FIFO has no rule to attribute to.
+logic ovf_fire;
+
+assign ovf_fire = pkt_first & reject_this;
+
+always_ff @(posedge nclk) begin
+    if (~nresetn || ctr_clear) begin
+        ovf_total <= '0;
+        for (int i = 0; i < N_RULES; i++) ovf_count[i] <= '0;
+    end else if (ovf_fire) begin
+        ovf_total <= ovf_total + 32'd1;
+        if (s_axis_tid[TAG_VALID_BIT])
+            ovf_count[s_axis_tid[TAG_ID_LSB +: RULE_ID_BITS]] <=
+                ovf_count[s_axis_tid[TAG_ID_LSB +: RULE_ID_BITS]] + 32'd1;
+    end
+end
+
+/**
+ * Stream out
+ */
+assign s_axis_tready = m_axis_tready;
+
+assign m_axis_tvalid = s2_valid;
+assign m_axis_tdata  = out_word[0                       +: DATA_BITS];
+assign m_axis_tkeep  = out_word[DATA_BITS               +: KEEP_BITS];
+assign m_axis_tlast  = out_word[DATA_BITS + KEEP_BITS];
+assign m_axis_tid    = out_word[DATA_BITS + KEEP_BITS + 1 +: TAG_BITS];
+
+endmodule

--- a/hw/hdl/network/denim/denim_drop.sv
+++ b/hw/hdl/network/denim/denim_drop.sv
@@ -1,0 +1,123 @@
+/**
+ * This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+ *
+ * MIT Licence
+ * Copyright (c) 2021-2026, Systems Group, ETH Zurich
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+`timescale 1ns / 1ps
+
+import denim_pkg::*;
+
+/**
+ * @brief   DENIM drop effect
+ *
+ * Removes every beat of a packet whose verdict tag carries the drop bit. The
+ * block reads only the tag, never the frame: the filter parsed the headers
+ * already.
+ *
+ * Suppression follows packet_filter: tvalid, tkeep and tlast are forced low
+ * downstream while the stream is consumed at full rate. Nothing is buffered,
+ * so a dropped packet costs no cycles and the sink never sees it.
+ *
+ */
+module denim_drop #(
+    parameter integer           DATA_BITS = 512
+) (
+    /* Network stream in, carrying the filter's verdict tag */
+    input  logic [DATA_BITS-1:0]    s_axis_tdata,
+    input  logic [DATA_BITS/8-1:0]  s_axis_tkeep,
+    input  logic                    s_axis_tlast,
+    input  logic                    s_axis_tvalid,
+    output logic                    s_axis_tready,
+    input  logic [TAG_BITS-1:0]     s_axis_tid,
+
+    /* Network stream out, tag passed on to the next effect block */
+    output logic [DATA_BITS-1:0]    m_axis_tdata,
+    output logic [DATA_BITS/8-1:0]  m_axis_tkeep,
+    output logic                    m_axis_tlast,
+    output logic                    m_axis_tvalid,
+    input  logic                    m_axis_tready,
+    output logic [TAG_BITS-1:0]     m_axis_tid,
+
+    /* Counters */
+    output logic [31:0]             drop_count,
+    input  logic                    ctr_clear,
+
+    input  logic                    nclk,
+    input  logic                    nresetn
+);
+
+/**
+ * Per-packet drop decision
+ */
+// Only the first beat of a packet carries a meaningful tag, so the verdict is
+// latched and held for the trailing beats: dropping just the header beat would
+// leave the payload behind as a runt frame.
+logic in_pkt_not_first;
+logic dropping_r;
+logic pkt_start;
+logic pkt_first;
+logic drop_this;
+
+assign pkt_start = ~in_pkt_not_first & s_axis_tvalid;
+assign pkt_first = pkt_start & s_axis_tready;
+assign drop_this = pkt_start ? (s_axis_tid[TAG_VALID_BIT] & s_axis_tid[TAG_MASK_LSB + EFF_DROP])
+                             : dropping_r;
+
+always_ff @(posedge nclk) begin
+    if (~nresetn) begin
+        in_pkt_not_first <= 1'b0;
+        dropping_r       <= 1'b0;
+    end else if (s_axis_tvalid & s_axis_tready) begin
+        in_pkt_not_first <= ~s_axis_tlast;
+        dropping_r       <= s_axis_tlast ? 1'b0 : drop_this;
+    end
+end
+
+/**
+ * Counters
+ */
+// Counted once per packet, on the beat that carried the decision, so the
+// figure is comparable with the filter's match_count for the same rule.
+always_ff @(posedge nclk) begin
+    if (~nresetn || ctr_clear) begin
+        drop_count <= '0;
+    end else if (pkt_first & drop_this) begin
+        drop_count <= drop_count + 32'd1;
+    end
+end
+
+/**
+ * Stream
+ */
+// tready comes straight from downstream and is never gated on drop_this: the
+// CMAC RX has no flow control, so a dropped packet must be consumed at line
+// rate rather than stalled off the wire.
+assign m_axis_tdata  = s_axis_tdata;
+assign m_axis_tid    = s_axis_tid;
+assign m_axis_tvalid = s_axis_tvalid & ~drop_this;
+assign m_axis_tkeep  = drop_this ? '0 : s_axis_tkeep;
+assign m_axis_tlast  = drop_this ? 1'b0 : s_axis_tlast;
+assign s_axis_tready = m_axis_tready;
+
+endmodule

--- a/hw/hdl/network/denim/denim_ecn.sv
+++ b/hw/hdl/network/denim/denim_ecn.sv
@@ -1,0 +1,152 @@
+/**
+ * This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+ *
+ * MIT Licence
+ * Copyright (c) 2021-2026, Systems Group, ETH Zurich
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+`timescale 1ns / 1ps
+
+import denim_pkg::*;
+
+/**
+ * @brief   DENIM ECN marking effect
+ *
+ * Sets the IPv4 ECN field to CE on the first beat of every packet whose verdict
+ * tag carries the ecn bit, and repairs the header checksum so the receiver's
+ * stack accepts the frame it has been handed.
+ *
+ * The block never re-parses. The tag is what guarantees the packet is IPv4 over
+ * Ethernet with a 20 byte header, so the two offsets touched here are known
+ * good, an untagged packet is not inspected at all.
+ *
+ * There is no pipeline stage and no added latency: the patch is a mux on the
+ * outgoing beat, so the block is a wire for every packet it does not mark.
+ */
+module denim_ecn #(
+    parameter integer           DATA_BITS = 512
+) (
+    /* Network stream in, with the verdict tag from upstream */
+    input  logic [DATA_BITS-1:0]    s_axis_tdata,
+    input  logic [DATA_BITS/8-1:0]  s_axis_tkeep,
+    input  logic                    s_axis_tlast,
+    input  logic                    s_axis_tvalid,
+    output logic                    s_axis_tready,
+    input  logic [TAG_BITS-1:0]     s_axis_tid,
+
+    /* Network stream out */
+    output logic [DATA_BITS-1:0]    m_axis_tdata,
+    output logic [DATA_BITS/8-1:0]  m_axis_tkeep,
+    output logic                    m_axis_tlast,
+    output logic                    m_axis_tvalid,
+    input  logic                    m_axis_tready,
+    output logic [TAG_BITS-1:0]     m_axis_tid,
+
+    /* Counters */
+    output logic [31:0]             ecn_count,
+    input  logic                    ctr_clear,
+
+    input  logic                    nclk,
+    input  logic                    nresetn
+);
+
+/**
+ * First beat detection
+ */
+// As in denim_filter: a register set on every accepted beat and cleared by
+// tlast, so the beat carrying the headers is the one where it reads zero.
+logic in_pkt_not_first;
+logic pkt_start;
+logic pkt_first;
+
+assign pkt_start = ~in_pkt_not_first & s_axis_tvalid;
+assign pkt_first = pkt_start & s_axis_tready;
+
+always_ff @(posedge nclk) begin
+    if (~nresetn) begin
+        in_pkt_not_first <= 1'b0;
+    end else if (s_axis_tvalid & s_axis_tready) begin
+        in_pkt_not_first <= ~s_axis_tlast;
+    end
+end
+
+/**
+ * ECN patch and incremental checksum
+ */
+// Byte 15 holds DSCP in its top six bits and ECN in its low two, and is the
+// low half of the 16 bit header word at bytes 14-15. Raising ECN therefore adds
+// delta to that word, and the checksum, being the complement of the header sum,
+// has to lose the same delta.
+logic        ecn_req;
+logic [1:0]  old_ecn;
+logic [1:0]  delta;
+logic [15:0] old_csum;
+logic [16:0] csum_sub;
+logic [15:0] new_csum;
+logic        mark_now;
+
+assign ecn_req  = s_axis_tid[TAG_VALID_BIT] & s_axis_tid[TAG_MASK_LSB + EFF_ECN];
+assign old_ecn  = s_axis_tdata[O_IP_TOS*8 +: 2];
+assign old_csum = {s_axis_tdata[O_IP_CSUM*8 +: 8], s_axis_tdata[(O_IP_CSUM+1)*8 +: 8]};
+assign delta    = 2'b11 - old_ecn;
+
+assign csum_sub = {1'b0, old_csum} - {15'b0, delta};
+assign new_csum = csum_sub[16] ? (csum_sub[15:0] - 16'd1) : csum_sub[15:0];
+
+assign mark_now = pkt_start & ecn_req & (delta != 2'b00);
+
+always_comb begin
+    m_axis_tdata = s_axis_tdata;
+    if (mark_now) begin
+        m_axis_tdata[O_IP_TOS*8 +: 2]      = 2'b11;
+        m_axis_tdata[O_IP_CSUM*8 +: 8]     = new_csum[15:8];
+        m_axis_tdata[(O_IP_CSUM+1)*8 +: 8] = new_csum[7:0];
+    end
+end
+
+/**
+ * Counters
+ */
+// Counts packets this block actually marked, so a packet that arrived already
+// CE is not counted. match_count in the filter already reports how many packets
+// asked for the effect, and the difference between the two is the traffic that
+// was congestion marked before it ever reached DENIM.
+always_ff @(posedge nclk) begin
+    if (~nresetn || ctr_clear) begin
+        ecn_count <= '0;
+    end else if (pkt_first & mark_now) begin
+        ecn_count <= ecn_count + 32'd1;
+    end
+end
+
+/**
+ * Stream passthrough
+ */
+// Only tdata is ever rewritten, and only in the beat mux above. tready comes
+// straight from downstream.
+assign m_axis_tkeep  = s_axis_tkeep;
+assign m_axis_tlast  = s_axis_tlast;
+assign m_axis_tvalid = s_axis_tvalid;
+assign m_axis_tid    = s_axis_tid;
+assign s_axis_tready = m_axis_tready;
+
+endmodule

--- a/hw/hdl/network/denim/denim_filter.sv
+++ b/hw/hdl/network/denim/denim_filter.sv
@@ -67,6 +67,10 @@ module denim_filter #(
     output logic [31:0]             roce_pkts,
     input  logic                    ctr_clear,
 
+    // Which relative rules have captured their base PSN, for readback.
+    output logic [N_RULES-1:0]      psn_captured,
+    output logic [N_RULES-1:0]      rule_armed,
+
     input  logic                    nclk,
     input  logic                    nresetn
 );
@@ -129,16 +133,61 @@ end
 // All slots compared in parallel; a condition whose enable is clear is a
 // wildcard, so a slot with no conditions matches every RoCE packet.
 logic [N_RULES-1:0] hit;
+logic [N_RULES-1:0] pre_hit;
+logic [N_RULES-1:0] psn_ok;
+logic [N_RULES-1:0] capture_now;
+
+logic [23:0] psn_lo_eff [N_RULES];
+logic [23:0] psn_hi_eff [N_RULES];
 
 always_comb begin
     for (int i = 0; i < N_RULES; i++) begin
-        hit[i] = rules[i].en && global_en && is_roce
-              && (!rules[i].qpn_en || (bth_qpn == rules[i].qpn))
-              && (!rules[i].psn_en || (bth_psn >= rules[i].psn_lo &&
-                                       bth_psn <= rules[i].psn_hi))
-              && (!rules[i].src_en || (ip_src == rules[i].ip_src))
-              && (!rules[i].dst_en || (ip_dst == rules[i].ip_dst))
-              && (!rules[i].op_en  || (bth_op == rules[i].opcode));
+        // Everything except the PSN condition.
+        pre_hit[i] = rules[i].en && global_en && is_roce
+                  && (!rules[i].qpn_en || (bth_qpn == rules[i].qpn))
+                  && (!rules[i].src_en || (ip_src == rules[i].ip_src))
+                  && (!rules[i].dst_en || (ip_dst == rules[i].ip_dst))
+                  && (!rules[i].op_en  || (bth_op == rules[i].opcode));
+
+        // A relative rule matches nothing until it has captured, the offset
+        // is meaningless before then.
+        psn_ok[i] = !rules[i].psn_en ? 1'b1
+                  : (!rules[i].psn_rel || psn_captured[i]) &&
+                    (bth_psn >= psn_lo_eff[i]) &&
+                    (bth_psn <= psn_hi_eff[i]);
+
+        hit[i] = pre_hit[i] && psn_ok[i] && rule_armed[i];
+
+        // The first packet matching everything but the PSN condition defines
+        // the base for a relative rule. It is not itself a match.
+        capture_now[i] = pkt_first && pre_hit[i] && rules[i].psn_rel &&
+                         !psn_captured[i];
+    end
+end
+
+/**
+ * Relative PSN base capture
+ */
+always_ff @(posedge nclk) begin
+    if (~nresetn) begin
+        psn_captured <= '0;
+        for (int i = 0; i < N_RULES; i++) begin
+            psn_lo_eff[i] <= '0;
+            psn_hi_eff[i] <= '0;
+        end
+    end else begin
+        for (int i = 0; i < N_RULES; i++) begin
+            if (!rules[i].en)        psn_captured[i] <= 1'b0;
+            else if (capture_now[i]) psn_captured[i] <= 1'b1;
+
+            if (!rules[i].psn_rel) begin
+                psn_lo_eff[i] <= rules[i].psn_lo;
+                psn_hi_eff[i] <= rules[i].psn_hi;
+            end else if (capture_now[i]) begin
+                psn_lo_eff[i] <= bth_psn + rules[i].psn_lo;
+                psn_hi_eff[i] <= bth_psn + rules[i].psn_hi;
+            end
+        end
     end
 end
 
@@ -167,24 +216,64 @@ end
  */
 // Latched on the first beat and held for the rest of the packet.
 logic [TAG_BITS-1:0] tag_new;
-logic [TAG_BITS-1:0] tag_held;
 
 assign tag_new = {win_mask, win_id, win_valid};
 
-always_ff @(posedge nclk) begin
-    if (~nresetn) begin
-        tag_held <= '0;
-    end else if (pkt_first) begin
-        tag_held <= tag_new;
+/**
+ * Shot limit
+ */
+// A rule may act on at most rules[i].shots packets, zero meaning unlimited
+// (default case).
+// The point is to be able to selectively introduce e.g. drops, for just
+// a limited number of packets.
+logic [15:0]        shot_count [N_RULES];
+logic [N_RULES-1:0] fire;
+logic [N_RULES-1:0] spent;
+
+always_comb begin
+    for (int i = 0; i < N_RULES; i++) begin
+        fire[i]  = pkt_first && win_valid && (win_id == i[RULE_ID_BITS-1:0]);
+        spent[i] = (rules[i].shots != 16'd0) &&
+                   ((shot_count[i] + 16'd1) >= rules[i].shots);
     end
 end
 
-assign m_axis_tid = pkt_start ? tag_new : tag_held;
+always_ff @(posedge nclk) begin
+    if (~nresetn) begin
+        rule_armed <= '1;
+        for (int i = 0; i < N_RULES; i++) shot_count[i] <= '0;
+    end else begin
+        for (int i = 0; i < N_RULES; i++) begin
+            // A disabled slot rearms and forgets its count.
+            if (!rules[i].en) begin
+                rule_armed[i] <= 1'b1;
+                shot_count[i] <= '0;
+            end else if (fire[i]) begin
+                shot_count[i] <= shot_count[i] + 16'd1;
+                if (spent[i]) rule_armed[i] <= 1'b0;
+            end
+        end
+    end
+end
 
 /**
  * Counters
  */
-// match_count tracks matching
+logic                    ctr_fire;
+logic                    ctr_valid;
+logic                    ctr_roce;
+logic [RULE_ID_BITS-1:0] ctr_id;
+
+always_ff @(posedge nclk) begin
+    // A clear discards a count still in flight.
+    if (~nresetn || ctr_clear) ctr_fire <= 1'b0;
+    else                       ctr_fire <= pkt_first;
+
+    ctr_valid <= win_valid;
+    ctr_roce  <= is_roce;
+    ctr_id    <= win_id;
+end
+
 always_ff @(posedge nclk) begin
     if (~nresetn || ctr_clear) begin
         all_pkts  <= '0;
@@ -192,25 +281,51 @@ always_ff @(posedge nclk) begin
         for (int i = 0; i < N_RULES; i++) begin
             match_count[i] <= '0;
         end
-    end else if (pkt_first) begin
+    end else if (ctr_fire) begin
         all_pkts <= all_pkts + 32'd1;
-        if (is_roce) begin
+        if (ctr_roce) begin
             roce_pkts <= roce_pkts + 32'd1;
         end
-        if (win_valid) begin
-            match_count[win_id] <= match_count[win_id] + 32'd1;
+        if (ctr_valid) begin
+            match_count[ctr_id] <= match_count[ctr_id] + 32'd1;
         end
     end
 end
 
 /**
- * Stream passthrough
+ * Output stage
  */
 // The filter observes and never modifies.
-assign m_axis_tdata  = s_axis_tdata;
-assign m_axis_tkeep  = s_axis_tkeep;
-assign m_axis_tlast  = s_axis_tlast;
-assign m_axis_tvalid = s_axis_tvalid;
+(* max_fanout = 64 *) logic out_en;
+
+assign out_en = m_axis_tready;
+
+always_ff @(posedge nclk) begin
+    if (~nresetn) begin
+        m_axis_tvalid <= 1'b0;
+        m_axis_tlast  <= 1'b0;
+    end else if (out_en) begin
+        m_axis_tvalid <= s_axis_tvalid;
+        m_axis_tlast  <= s_axis_tlast;
+    end
+end
+
+always_ff @(posedge nclk) begin
+    if (out_en) begin
+        m_axis_tdata <= s_axis_tdata;
+        m_axis_tkeep <= s_axis_tkeep;
+    end
+end
+
+always_ff @(posedge nclk) begin
+    if (~nresetn) begin
+        m_axis_tid <= '0;
+    end else if (pkt_first) begin
+        m_axis_tid <= tag_new;
+    end
+end
+
+// tready comes straight from downstream
 assign s_axis_tready = m_axis_tready;
 
 endmodule

--- a/hw/hdl/network/denim/denim_filter.sv
+++ b/hw/hdl/network/denim/denim_filter.sv
@@ -1,0 +1,216 @@
+/**
+ * This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+ *
+ * MIT Licence
+ * Copyright (c) 2021-2026, Systems Group, ETH Zurich
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+`timescale 1ns / 1ps
+
+import denim_pkg::*;
+
+/**
+ * @brief   DENIM match filter
+ *
+ * Parses the first beat of every frame, compares it against all rule slots in
+ * parallel and emits a verdict tag alongside the unmodified stream. The tag is
+ * the composability contract: the parse happens here exactly once, and every
+ * effect block downstream reads only the tag. Adding an effect is then one
+ * pipeline stage and one mask bit, never a change to this parser.
+ *
+ */
+module denim_filter #(
+    parameter integer           DATA_BITS = 512
+) (
+    /* Network stream in */
+    input  logic [DATA_BITS-1:0]    s_axis_tdata,
+    input  logic [DATA_BITS/8-1:0]  s_axis_tkeep,
+    input  logic                    s_axis_tlast,
+    input  logic                    s_axis_tvalid,
+    output logic                    s_axis_tready,
+
+    /* Network stream out, plus the verdict tag */
+    output logic [DATA_BITS-1:0]    m_axis_tdata,
+    output logic [DATA_BITS/8-1:0]  m_axis_tkeep,
+    output logic                    m_axis_tlast,
+    output logic                    m_axis_tvalid,
+    input  logic                    m_axis_tready,
+    output logic [TAG_BITS-1:0]     m_axis_tid,
+
+    /* Rule table, already in the nclk domain */
+    input  denim_rule_t             rules [N_RULES],
+    input  logic                    global_en,
+    input  logic [15:0]             roce_port,
+
+    /* Counters */
+    output logic [31:0]             match_count [N_RULES],
+    output logic [31:0]             all_pkts,
+    output logic [31:0]             roce_pkts,
+    input  logic                    ctr_clear,
+
+    input  logic                    nclk,
+    input  logic                    nresetn
+);
+
+/**
+ * First beat detection
+ */
+logic in_pkt_not_first;
+logic pkt_start;
+logic pkt_first;
+
+assign pkt_start = ~in_pkt_not_first & s_axis_tvalid;
+assign pkt_first = pkt_start & s_axis_tready;
+
+always_ff @(posedge nclk) begin
+    if (~nresetn) begin
+        in_pkt_not_first <= 1'b0;
+    end else if (s_axis_tvalid & s_axis_tready) begin
+        in_pkt_not_first <= ~s_axis_tlast;
+    end
+end
+
+/**
+ * Field extraction
+ */
+logic [15:0] eth_type;
+logic [15:0] udp_dport;
+logic [7:0]  ip_proto;
+logic [7:0]  bth_op;
+logic [31:0] ip_src;
+logic [31:0] ip_dst;
+logic [23:0] bth_qpn;
+logic [23:0] bth_psn;
+logic        is_roce;
+
+always_comb begin
+    eth_type  = {s_axis_tdata[O_ETHERTYPE*8 +: 8], s_axis_tdata[(O_ETHERTYPE+1)*8 +: 8]};
+    ip_proto  =  s_axis_tdata[O_IP_PROTO*8 +: 8];
+    udp_dport = {s_axis_tdata[O_UDP_DPORT*8 +: 8], s_axis_tdata[(O_UDP_DPORT+1)*8 +: 8]};
+    ip_src    = {s_axis_tdata[O_IP_SRC*8 +: 8],    s_axis_tdata[(O_IP_SRC+1)*8 +: 8],
+                 s_axis_tdata[(O_IP_SRC+2)*8 +: 8], s_axis_tdata[(O_IP_SRC+3)*8 +: 8]};
+    ip_dst    = {s_axis_tdata[O_IP_DST*8 +: 8],    s_axis_tdata[(O_IP_DST+1)*8 +: 8],
+                 s_axis_tdata[(O_IP_DST+2)*8 +: 8], s_axis_tdata[(O_IP_DST+3)*8 +: 8]};
+    bth_op    =  s_axis_tdata[O_BTH_OP*8 +: 8];
+    bth_qpn   = {s_axis_tdata[O_BTH_QPN*8 +: 8], s_axis_tdata[(O_BTH_QPN+1)*8 +: 8],
+                 s_axis_tdata[(O_BTH_QPN+2)*8 +: 8]};
+    bth_psn   = {s_axis_tdata[O_BTH_PSN*8 +: 8], s_axis_tdata[(O_BTH_PSN+1)*8 +: 8],
+                 s_axis_tdata[(O_BTH_PSN+2)*8 +: 8]};
+
+    // Anything that is not IPv4/UDP on the RoCE port keeps its extracted
+    // fields meaningless and can never match. Not parsing something DENIM
+    // is supposed to not understand.
+    is_roce   = (eth_type == ETHERTYPE_IPV4) && (ip_proto == IP_PROTO_UDP) &&
+                (udp_dport == roce_port);
+end
+
+/**
+ * Match
+ */
+// All slots compared in parallel; a condition whose enable is clear is a
+// wildcard, so a slot with no conditions matches every RoCE packet.
+logic [N_RULES-1:0] hit;
+
+always_comb begin
+    for (int i = 0; i < N_RULES; i++) begin
+        hit[i] = rules[i].en && global_en && is_roce
+              && (!rules[i].qpn_en || (bth_qpn == rules[i].qpn))
+              && (!rules[i].psn_en || (bth_psn >= rules[i].psn_lo &&
+                                       bth_psn <= rules[i].psn_hi))
+              && (!rules[i].src_en || (ip_src == rules[i].ip_src))
+              && (!rules[i].dst_en || (ip_dst == rules[i].ip_dst))
+              && (!rules[i].op_en  || (bth_op == rules[i].opcode));
+    end
+end
+
+// First match wins, so slot order is match priority and denim_ctl can map
+// rule file order onto it directly. Walking downwards leaves the lowest
+// matching index as the surviving assignment.
+logic                    win_valid;
+logic [RULE_ID_BITS-1:0] win_id;
+logic [3:0]              win_mask;
+
+always_comb begin
+    win_valid = 1'b0;
+    win_id    = '0;
+    win_mask  = '0;
+    for (int i = N_RULES - 1; i >= 0; i--) begin
+        if (hit[i]) begin
+            win_valid = 1'b1;
+            win_id    = i[RULE_ID_BITS-1:0];
+            win_mask  = rules[i].eff_mask;
+        end
+    end
+end
+
+/**
+ * Verdict tag
+ */
+// Latched on the first beat and held for the rest of the packet.
+logic [TAG_BITS-1:0] tag_new;
+logic [TAG_BITS-1:0] tag_held;
+
+assign tag_new = {win_mask, win_id, win_valid};
+
+always_ff @(posedge nclk) begin
+    if (~nresetn) begin
+        tag_held <= '0;
+    end else if (pkt_first) begin
+        tag_held <= tag_new;
+    end
+end
+
+assign m_axis_tid = pkt_start ? tag_new : tag_held;
+
+/**
+ * Counters
+ */
+// match_count tracks matching
+always_ff @(posedge nclk) begin
+    if (~nresetn || ctr_clear) begin
+        all_pkts  <= '0;
+        roce_pkts <= '0;
+        for (int i = 0; i < N_RULES; i++) begin
+            match_count[i] <= '0;
+        end
+    end else if (pkt_first) begin
+        all_pkts <= all_pkts + 32'd1;
+        if (is_roce) begin
+            roce_pkts <= roce_pkts + 32'd1;
+        end
+        if (win_valid) begin
+            match_count[win_id] <= match_count[win_id] + 32'd1;
+        end
+    end
+end
+
+/**
+ * Stream passthrough
+ */
+// The filter observes and never modifies.
+assign m_axis_tdata  = s_axis_tdata;
+assign m_axis_tkeep  = s_axis_tkeep;
+assign m_axis_tlast  = s_axis_tlast;
+assign m_axis_tvalid = s_axis_tvalid;
+assign s_axis_tready = m_axis_tready;
+
+endmodule

--- a/hw/hdl/network/denim/denim_pkg.sv
+++ b/hw/hdl/network/denim/denim_pkg.sv
@@ -75,6 +75,9 @@ typedef struct packed {
     logic        en;
     logic        qpn_en;
     logic        psn_en;
+    // psn_lo and psn_hi are offsets from the connection's first observed PSN
+    // rather than absolute values.
+    logic        psn_rel;
     logic        src_en;
     logic        dst_en;
     logic        op_en;
@@ -86,6 +89,8 @@ typedef struct packed {
     logic [7:0]  opcode;
     logic [3:0]  eff_mask;
     logic [31:0] eff_param;
+    // How many packets this rule may act on before it disarms itself.
+    logic [15:0] shots;
 } denim_rule_t;
 
 endpackage

--- a/hw/hdl/network/denim/denim_pkg.sv
+++ b/hw/hdl/network/denim/denim_pkg.sv
@@ -1,0 +1,91 @@
+/**
+ * This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+ *
+ * MIT Licence
+ * Copyright (c) 2021-2026, Systems Group, ETH Zurich
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+`timescale 1ns / 1ps
+
+/**
+ * @brief   DENIM shared definitions
+ *
+ * One source of truth for the verdict tag layout, the frame byte offsets and
+ * the rule record.
+ */
+package denim_pkg;
+
+localparam integer N_RULES      = 8;
+localparam integer RULE_ID_BITS = $clog2(N_RULES);
+localparam integer TAG_BITS     = 8;
+
+// Verdict tag layout: {effect_mask[3:0], rule_id[2:0], valid}. A bitmask
+// rather than an enum, so several effects chain within one rule.
+localparam integer TAG_VALID_BIT = 0;
+localparam integer TAG_ID_LSB    = 1;
+localparam integer TAG_MASK_LSB  = 4;
+
+// Effect bit positions, within eff_mask and within tag[7:4] alike.
+localparam integer EFF_ECN   = 0;
+localparam integer EFF_DROP  = 1;
+localparam integer EFF_DELAY = 2;
+localparam integer EFF_COUNT = 3;
+
+// Frame byte offsets, assuming a 20 byte IPv4 header and no VLAN tag (the
+// same simplifications packet_filter already makes).
+localparam integer O_ETHERTYPE = 12;
+localparam integer O_IP_TOS    = 15;
+localparam integer O_IP_PROTO  = 23;
+localparam integer O_IP_CSUM   = 24;
+localparam integer O_IP_SRC    = 26;
+localparam integer O_IP_DST    = 30;
+localparam integer O_UDP_DPORT = 36;
+localparam integer O_BTH_OP    = 42;
+localparam integer O_BTH_QPN   = 47;
+localparam integer O_BTH_PSN   = 51;
+
+localparam logic [15:0] ETHERTYPE_IPV4 = 16'h0800;
+localparam logic [7:0]  IP_PROTO_UDP   = 8'h11;
+
+localparam logic [15:0] ROCE_UDP_PORT = 16'h12b7;
+
+// A rule slot. Each condition carries its own enable, and a disabled
+// condition is a wildcard, so a slot with none enabled matches every RoCE
+// packet.
+typedef struct packed {
+    logic        en;
+    logic        qpn_en;
+    logic        psn_en;
+    logic        src_en;
+    logic        dst_en;
+    logic        op_en;
+    logic [23:0] qpn;
+    logic [23:0] psn_lo;
+    logic [23:0] psn_hi;
+    logic [31:0] ip_src;
+    logic [31:0] ip_dst;
+    logic [7:0]  opcode;
+    logic [3:0]  eff_mask;
+    logic [31:0] eff_param;
+} denim_rule_t;
+
+endpackage

--- a/hw/hdl/network/denim/denim_top.sv
+++ b/hw/hdl/network/denim/denim_top.sv
@@ -1,0 +1,86 @@
+/**
+ * This file is part of the Coyote <https://github.com/fpgasystems/Coyote>
+ *
+ * MIT Licence
+ * Copyright (c) 2021-2026, Systems Group, ETH Zurich
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+`timescale 1ns / 1ps
+
+import lynxTypes::*;
+
+/**
+ * @brief   DENIM top level
+ *
+ * In-path network impairment on the RX stream, between the CMAC and the IP
+ * handler, and ahead of the packet sniffer tap so that captures show the
+ * traffic as the RDMA stack will see it.
+ *
+ * This module is the only part of DENIM that knows about Coyote.
+ *
+ * With no rule armed the chain is transparent apart from the delay FIFO's
+ * cut-through latency.
+ */
+module denim_top (
+    /* Network stream, nclk domain */
+    AXI4S.s                     s_axis_net,
+    AXI4S.m                     m_axis_net,
+
+    /* Config in and register mirror out, crossed from aclk in network_top */
+    metaIntf.s                  s_denim_cnfg,
+    metaIntf.m                  m_denim_stat,
+
+    input  wire                 nclk,
+    input  wire                 nresetn_r
+);
+
+// FIFO_BEATS sets how much delay the block can hold at line rate
+denim_chain #(
+    .DATA_BITS      (AXI_NET_BITS),
+    .FIFO_BEATS     (4096),
+    .PMTU_BYTES     (PMTU_BYTES)
+) inst_chain (
+    .s_axis_tdata   (s_axis_net.tdata),
+    .s_axis_tkeep   (s_axis_net.tkeep),
+    .s_axis_tlast   (s_axis_net.tlast),
+    .s_axis_tvalid  (s_axis_net.tvalid),
+    .s_axis_tready  (s_axis_net.tready),
+
+    .m_axis_tdata   (m_axis_net.tdata),
+    .m_axis_tkeep   (m_axis_net.tkeep),
+    .m_axis_tlast   (m_axis_net.tlast),
+    .m_axis_tvalid  (m_axis_net.tvalid),
+    .m_axis_tready  (m_axis_net.tready),
+
+    .s_cnfg_tdata   (s_denim_cnfg.data),
+    .s_cnfg_tvalid  (s_denim_cnfg.valid),
+    .s_cnfg_tready  (s_denim_cnfg.ready),
+
+    .m_stat_tdata   (m_denim_stat.data),
+    .m_stat_tvalid  (m_denim_stat.valid),
+    .m_stat_tready  (m_denim_stat.ready),
+
+    .nclk           (nclk),
+    .nresetn        (nresetn_r)
+);
+
+endmodule

--- a/hw/hdl/network/denim/denim_top.sv
+++ b/hw/hdl/network/denim/denim_top.sv
@@ -56,7 +56,8 @@ module denim_top (
 // FIFO_BEATS sets how much delay the block can hold at line rate
 denim_chain #(
     .DATA_BITS      (AXI_NET_BITS),
-    .FIFO_BEATS     (4096),
+    .FIFO_BEATS     (512),
+    .META_ENTRIES   (256),
     .PMTU_BYTES     (PMTU_BYTES)
 ) inst_chain (
     .s_axis_tdata   (s_axis_net.tdata),

--- a/hw/hdl/network/stack/network_stack.sv
+++ b/hw/hdl/network/stack/network_stack.sv
@@ -109,6 +109,11 @@ module network_stack #(
     metaIntf.s                  s_filter_config,
 `endif
 
+`ifdef EN_DENIM
+    metaIntf.s                  s_denim_cnfg,
+    metaIntf.m                  m_denim_stat,
+`endif
+
     /* Network streams */
     AXI4S.s                     s_axis_net,
     AXI4S.m                     m_axis_net
@@ -311,9 +316,32 @@ vio_ip inst_vio_ip (
 );
 
 /**
+ * DENIM
+ *
+ * In-path impairment, placed ahead of the sniffer tap so that captures show
+ * the traffic as the RDMA stack will see it, with effects already applied.
+ * Useful for tracking that e.g. ECN marking was applied. 
+ */
+`ifdef EN_DENIM
+AXI4S #(.AXI4S_DATA_BITS(AXI_NET_BITS)) axis_slice_to_denim();
+
+axis_reg       inst_sniffer_slice_0 (.aclk(nclk), .aresetn(nresetn_r), .s_axis(s_axis_net), .m_axis(axis_slice_to_denim));
+
+denim_top inst_denim (
+    .s_axis_net(axis_slice_to_denim),
+    .m_axis_net(axis_slice_to_sniffer),
+    .s_denim_cnfg(s_denim_cnfg),
+    .m_denim_stat(m_denim_stat),
+    .nclk(nclk),
+    .nresetn_r(nresetn_r)
+);
+`else
+axis_reg       inst_sniffer_slice_0 (.aclk(nclk), .aresetn(nresetn_r), .s_axis(s_axis_net), .m_axis(axis_slice_to_sniffer));
+`endif
+
+/**
  * Packet Sniffer
  */
-axis_reg       inst_sniffer_slice_0 (.aclk(nclk), .aresetn(nresetn_r), .s_axis(s_axis_net), .m_axis(axis_slice_to_sniffer));
 
 `ifdef EN_SNIFFER
 axis_reg_array inst_sniffer_slice_1 (.aclk(nclk), .aresetn(nresetn_r), .s_axis(axis_macmerger_to_sniffer_slice), .m_axis(axis_sniffer_slice_to_sniffer));

--- a/hw/hdl/network/stack/network_top.sv
+++ b/hw/hdl/network/stack/network_top.sv
@@ -106,6 +106,11 @@ module network_top #(
     metaIntf.s                  s_filter_config,
 `endif
 
+`ifdef EN_DENIM
+    metaIntf.s                  s_denim_cnfg,
+    metaIntf.m                  m_denim_stat,
+`endif
+
     // Clocks
     input  wire                 aclk,
     input  wire                 aresetn,
@@ -283,6 +288,32 @@ logic [N_REG_NET_S0:0][63:0] ddr_offset_addr_tcp;
 AXI4 axi_tcp_ddr_slice ();
 
 /**
+ * DENIM config transport
+ */
+`ifdef EN_DENIM
+metaIntf #(.STYPE(logic[71:0])) denim_cnfg_nclk ();
+metaIntf #(.STYPE(logic[71:0])) denim_stat_nclk ();
+
+meta_ccross #(.DATA_BITS(72)) inst_denim_cnfg_ccross (
+    .s_aclk(aclk),
+    .s_aresetn(aresetn),
+    .m_aclk(n_clk),
+    .m_aresetn(n_resetn),
+    .s_meta(s_denim_cnfg),
+    .m_meta(denim_cnfg_nclk)
+);
+
+meta_ccross #(.DATA_BITS(72)) inst_denim_stat_ccross (
+    .s_aclk(n_clk),
+    .s_aresetn(n_resetn),
+    .m_aclk(aclk),
+    .m_aresetn(aresetn),
+    .s_meta(denim_stat_nclk),
+    .m_meta(m_denim_stat)
+);
+`endif
+
+/**
  * Network stack
  */
 network_stack inst_network_stack (
@@ -342,6 +373,11 @@ network_stack inst_network_stack (
     .m_rx_sniffer(m_rx_sniffer),
     .m_tx_sniffer(m_tx_sniffer),
     .s_filter_config(s_filter_config),
+`endif
+
+`ifdef EN_DENIM
+    .s_denim_cnfg(denim_cnfg_nclk),
+    .m_denim_stat(denim_stat_nclk),
 `endif
 
     .nclk(n_clk),

--- a/hw/templates/common/dynamic_top_tmplt.txt
+++ b/hw/templates/common/dynamic_top_tmplt.txt
@@ -104,6 +104,10 @@ module design_dynamic_top #(
     AXI4S.s                                     s_tx_sniffer,
     metaIntf.m                                  m_filter_config,
 {% endif %}
+{% if cnfg.en_denim %}
+    metaIntf.m                                  m_denim_cnfg,
+    metaIntf.s                                  s_denim_stat,
+{% endif %}
 
 {% if cnfg.en_wb %}
     // Writeback
@@ -1224,6 +1228,15 @@ module design_dynamic_top #(
         .filter_config_data(m_filter_config.data),
         .filter_config_ready(m_filter_config.ready),
         .filter_config_valid(m_filter_config.valid),
+{% endif %}
+
+{% if ( cnfg.en_denim and ( cnfg.denim_vfpga_id == i ) ) %}
+        .denim_cnfg_data(m_denim_cnfg.data),
+        .denim_cnfg_ready(m_denim_cnfg.ready),
+        .denim_cnfg_valid(m_denim_cnfg.valid),
+        .denim_stat_data(s_denim_stat.data),
+        .denim_stat_ready(s_denim_stat.ready),
+        .denim_stat_valid(s_denim_stat.valid),
 {% endif %}
 
 {% if cnfg.fpga_arch == 'ultrascale_plus' %}

--- a/hw/templates/common/lynx_pkg_tmplt.txt
+++ b/hw/templates/common/lynx_pkg_tmplt.txt
@@ -59,6 +59,9 @@
 {% if cnfg.en_sniffer %}
 `define EN_SNIFFER
 {% endif %}
+{% if cnfg.en_denim %}
+`define EN_DENIM
+{% endif %}
 {% if cnfg.en_net_0 %}
 `define EN_NET_0
 {% endif %}
@@ -155,6 +158,8 @@ package lynxTypes;
     localparam integer AXI_ADDR_BITS = 64;
     localparam integer AXI_NET_BITS = 512;
     localparam integer AXI_DDR_BITS = 512;
+    // DENIM verdict tag: {effect_mask[3:0], rule_id[2:0], valid}
+    localparam integer DENIM_TAG_BITS = 8;
     localparam integer AXI_TLB_BITS = 128;
     localparam integer AXI_ID_BITS = 6;
     localparam integer AXI_BPSS_BAR_BITS = 28;

--- a/hw/templates/common/shell_top_tmplt.txt
+++ b/hw/templates/common/shell_top_tmplt.txt
@@ -777,6 +777,10 @@ module shell_top (
     AXI4S #(.AXI4S_DATA_BITS(AXI_NET_BITS)) tx_sniffer ();
     metaIntf #(.STYPE(logic[64-1:0])) filter_config ();
 {% endif %}
+{% if cnfg.en_denim %}
+    metaIntf #(.STYPE(logic[72-1:0])) denim_cnfg ();
+    metaIntf #(.STYPE(logic[72-1:0])) denim_stat ();
+{% endif %}
     
     network_top #(
 {% if cnfg.en_nclk %}
@@ -843,6 +847,10 @@ module shell_top (
         .m_rx_sniffer(rx_sniffer),
         .m_tx_sniffer(tx_sniffer),
         .s_filter_config(filter_config),
+{% endif %}
+{% if cnfg.en_denim %}
+        .s_denim_cnfg(denim_cnfg),
+        .m_denim_stat(denim_stat),
 {% endif %}
         .aclk(aclk),
         .aresetn(aresetn),
@@ -1529,6 +1537,10 @@ module shell_top (
         .s_rx_sniffer(rx_sniffer),
         .s_tx_sniffer(tx_sniffer),
         .m_filter_config(filter_config),
+{% endif %}
+{% if cnfg.en_denim %}
+        .m_denim_cnfg(denim_cnfg),
+        .s_denim_stat(denim_stat),
 {% endif %}
 {% if cnfg.en_wb %}
         .m_wback(wback),

--- a/hw/templates/common/user_logic_tmplt.txt
+++ b/hw/templates/common/user_logic_tmplt.txt
@@ -88,6 +88,10 @@ module design_user_logic_c{{ c_cnfg }}_{{ c_reg }} (
     AXI4S.s                     axis_tx_sniffer,
     metaIntf.m                  filter_config,
 {% endif %}
+{% if ( cnfg.en_denim and ( cnfg.denim_vfpga_id == c_reg ) ) %}
+    metaIntf.m                  denim_cnfg,
+    metaIntf.s                  denim_stat,
+{% endif %}
 
     // Clock and reset
     input  wire                 aclk,

--- a/hw/templates/common/user_wrapper_tmplt.txt
+++ b/hw/templates/common/user_wrapper_tmplt.txt
@@ -191,6 +191,14 @@ module design_user_wrapper_{{ c_reg }} (
     (* io_buffer_type = "none" *) input  logic                                filter_config_ready,
     (* io_buffer_type = "none" *) output logic                                filter_config_valid,
 {% endif %}
+{% if ( cnfg.en_denim and ( cnfg.denim_vfpga_id == c_reg ) ) %}
+    (* io_buffer_type = "none" *) output logic[72-1:0]                        denim_cnfg_data,
+    (* io_buffer_type = "none" *) input  logic                                denim_cnfg_ready,
+    (* io_buffer_type = "none" *) output logic                                denim_cnfg_valid,
+    (* io_buffer_type = "none" *) input  logic[72-1:0]                        denim_stat_data,
+    (* io_buffer_type = "none" *) output logic                                denim_stat_ready,
+    (* io_buffer_type = "none" *) input  logic                                denim_stat_valid,
+{% endif %}
 
 {% if cnfg.fpga_arch == 'ultrascale_plus' %}
     // Debug
@@ -476,6 +484,12 @@ module design_user_wrapper_{{ c_reg }} (
     AXI4S #(.AXI4S_DATA_BITS(AXI_NET_BITS)) rx_sniffer (.*);
     AXI4S #(.AXI4S_DATA_BITS(AXI_NET_BITS)) tx_sniffer (.*);
     metaIntf #(.STYPE(logic[64-1:0])) filter_config (.*);
+{% endif %}
+{% if ( cnfg.en_denim and ( cnfg.denim_vfpga_id == c_reg ) ) %}
+    metaIntf #(.STYPE(logic[72-1:0])) denim_cnfg (.*);
+    metaIntf #(.STYPE(logic[72-1:0])) denim_stat (.*);
+{% endif %}
+{% if cnfg.en_sniffer %}
 
     assign rx_sniffer.tdata          = rx_sniffer_tdata;
     assign rx_sniffer.tkeep          = rx_sniffer_tkeep;
@@ -490,6 +504,14 @@ module design_user_wrapper_{{ c_reg }} (
     assign filter_config.data        = filter_config_data;
     assign filter_config.ready       = filter_config_ready;
     assign filter_config.valid       = filter_config_valid;
+{% endif %}
+{% if ( cnfg.en_denim and ( cnfg.denim_vfpga_id == c_reg ) ) %}
+    assign denim_cnfg_data           = denim_cnfg.data;
+    assign denim_cnfg.ready          = denim_cnfg_ready;
+    assign denim_cnfg_valid          = denim_cnfg.valid;
+    assign denim_stat.data           = denim_stat_data;
+    assign denim_stat_ready          = denim_stat.ready;
+    assign denim_stat.valid          = denim_stat_valid;
 {% endif %}
 
 {% if cnfg.en_user_reg %}
@@ -1112,6 +1134,10 @@ module design_user_wrapper_{{ c_reg }} (
         .axis_rx_sniffer(rx_sniffer),
         .axis_tx_sniffer(tx_sniffer),
         .filter_config(filter_config),
+{% endif %}
+{% if ( cnfg.en_denim and ( cnfg.denim_vfpga_id == c_reg ) ) %}
+        .denim_cnfg(denim_cnfg),
+        .denim_stat(denim_stat),
     {% endif %}
         .aclk(aclk),
 	    .aresetn(aresetn)

--- a/scripts/base.tcl.in
+++ b/scripts/base.tcl.in
@@ -102,6 +102,8 @@ set cfg(en_rdma)                ${EN_RDMA}
 set cfg(en_tcp)                 ${EN_TCP}   
 set cfg(en_sniffer)             ${EN_SNIFFER}
 set cfg(sniffer_vfpga_id)       ${SNIFFER_VFPGA_ID}
+set cfg(en_denim)               ${EN_DENIM}
+set cfg(denim_vfpga_id)         ${DENIM_VFPGA_ID}
 set cfg(en_net_0)               ${EN_NET_0}
 set cfg(en_net_1)               ${EN_NET_1}
 set cfg(en_net)                 ${EN_NET}   

--- a/scripts/cr_prjcts/cr_shell.tcl.in
+++ b/scripts/cr_prjcts/cr_shell.tcl.in
@@ -101,6 +101,9 @@ if {$cfg(en_net) eq 1} {
     if {$cfg(en_tcp) eq 1} {
         add_files "$hw_dir/hdl/network/tcp"
     }
+    if {$cfg(en_denim) eq 1} {
+        add_files "$hw_dir/hdl/network/denim"
+    }
 }
 add_files "$proj_dir/hdl"
 


### PR DESCRIPTION
## Description

DENIM is an in-path impairment module for RoCE v2 traffic, sitting in the service layer
(`nclk` domain) so that experiments can inject deterministic network events at the endpoint.

A stateless filter matches the first 64B beat of each frame against 8 rule slots and emits a
verdict tag `{valid, rule_id, effect_mask}`. Chained effect blocks (ECN / drop / delay) act on
the tag only. Rules are written as
`<cond>[, <cond>...] : <effect>[, <effect>]`, e.g. `qpn 3, psn 50-150 : ecn, delay 1us`.
Two constructs make impairments repeatable across runs: `psn +K` addresses packets by
position in the flow rather than by absolute PSN (the base is captured in hardware from the
connection's first packet), and `once` / `shots N` bound how many packets a rule may act on,
so a rule can inject e.g. transient loss.

Everything is behind `EN_DENIM` and off by default. Includes a control vFPGA CSR slave,
`denim_ctl` for driving it from software, and `examples/13_denim` with documentation.

## Type of change
- [x] New feature

## Tests & Results
**Simulation.** 15 xsim testbenches, covering field extraction, match priority, effect chaining, relative-PSN capture,
shot limits, delay FIFO overflow, and the CSR path. The rule parser has its own host-side unit tests. 

**Timing.** Full shell build for `u55c`: **WNS +0.046 ns, WHS +0.019 ns, 0 failing
endpoints** of ~1.5M.

**Hardware E2E tests.** Two Alveo U55C nodes, `09_perf_rdma` as the traffic source, DENIM on the receiving
node. 

**Not yet covered:**  TODO PCAP level verification

### IMPORTANT
- Most of my DENIM builds were done with Vivado 2024.1, and tried a few with 2024.2 and that
also worked well. Can only vouch for builds generated with these two Vivado versions.


### Checklist
- [x] I have commented my code and made corresponding changes to the documentation.
- [x] I have added tests/results that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings or errors & all tests successfully pass.
