### PR TITLE
driver: memory-safety and locking fixes

### DIFF
--- a/driver/include/coyote_defs.h
+++ b/driver/include/coyote_defs.h
@@ -1063,7 +1063,7 @@ struct reconfig_dev {
     struct mutex rcnfg_lock;
 
     /// Memory lock, ensuring no conditions occur when allocating buffers for reconfiguration
-    spinlock_t mem_lock;
+    struct mutex mem_lock;
 
     /// Waitqueue for the reconfiguration
     wait_queue_head_t waitqueue_rcnfg;

--- a/driver/include/coyote_defs.h
+++ b/driver/include/coyote_defs.h
@@ -793,9 +793,13 @@ struct pf_aligned_desc {
  * Holds all the information needed to perform reconfiguration with this buffer,
  * where the buffer holds the partial bitstream to be loaded
  */
+struct reconfig_dev;
+
 struct reconfig_buff_metadata {
     /// Hash table entry for easy lookups in reconfig_buffs_map
     struct hlist_node entry;
+
+    struct reconfig_dev *device;
 
     /// Buffer starting virtual address
     uint64_t vaddr;

--- a/driver/include/coyote_defs.h
+++ b/driver/include/coyote_defs.h
@@ -58,6 +58,7 @@
 #include <linux/poll.h>
 #include <asm/delay.h>
 #include <linux/mutex.h>
+#include <linux/semaphore.h>
 #include <linux/rwsem.h>
 #include <asm/set_memory.h>
 #include <linux/hashtable.h>
@@ -845,7 +846,7 @@ extern struct hlist_head reconfig_buffs_map[1 << (RECONFIG_HASH_TABLE_ORDER)];
 extern struct eventfd_ctx *user_notifier[MAX_N_REGIONS][N_CTID_MAX];
 
 /// Interrupt locks, ensuring that only one interrupt (per vFPGA and cThread) is processed at a time and that the user space can safely read/write to the eventfd context
-extern struct mutex user_notifier_lock[MAX_N_REGIONS][N_CTID_MAX];
+extern struct semaphore user_notifier_lock[MAX_N_REGIONS][N_CTID_MAX];
 
 /// Interrupt values used to pass values between vpfga_isr and vpfga_ops
 extern int32_t interrupt_value[MAX_N_REGIONS][N_CTID_MAX];

--- a/driver/include/reconfig/reconfig_mem.h
+++ b/driver/include/reconfig/reconfig_mem.h
@@ -46,17 +46,5 @@
  */
 int alloc_reconfig_buffer(struct reconfig_dev *device, unsigned long n_pages, pid_t pid, uint32_t crid);
 
-/**
- * @brief De-allocates host-side, kernel-space reconfiguration buffer
- *
- * Performs the opposite of the function above; to be used when reconfiguration is complete
- *
- * @param device reconfig_device for which the bitstream buffer should be allocated
- * @param vaddr buffer virtual address
- * @param pid host process ID
- * @param crid configuration ID 
- * @return always 0; check reconfig_mem.c for explanation
- */
-int free_reconfig_buffer(struct reconfig_dev *device, uint64_t vaddr, pid_t pid, uint32_t crid);
 
 #endif // _RECONFIG_MEM_H_

--- a/driver/include/vfpga/vfpga_gup.h
+++ b/driver/include/vfpga/vfpga_gup.h
@@ -46,6 +46,11 @@
 #include "vfpga_hw.h"
 #include "coyote_defs.h"
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0)
+#define mmap_read_lock(mm) down_read(&(mm)->mmap_sem)
+#define mmap_read_unlock(mm) up_read(&(mm)->mmap_sem)
+#endif
+
 /**
  * @brief Top-level function; handles page faults issued by the FPGA
  *

--- a/driver/src/coyote_setup.c
+++ b/driver/src/coyote_setup.c
@@ -673,7 +673,7 @@ int setup_reconfig_device(struct bus_driver_data *data) {
     hash_init(reconfig_buffs_map);
     mutex_init(&data->reconfig_dev->rcnfg_lock);
     spin_lock_init(&data->reconfig_dev->irq_lock);
-    spin_lock_init(&data->reconfig_dev->mem_lock);
+    mutex_init(&data->reconfig_dev->mem_lock);
     init_waitqueue_head(&data->reconfig_dev->waitqueue_rcnfg);
     atomic_set(&data->reconfig_dev->wait_rcnfg, FLAG_CLR);
 

--- a/driver/src/reconfig/reconfig_hw.c
+++ b/driver/src/reconfig/reconfig_hw.c
@@ -37,6 +37,10 @@ int reconfigure_start(struct reconfig_dev *device, uint64_t vaddr, uint64_t len,
         if (tmp_buff->vaddr == vaddr && tmp_buff->pid == pid && tmp_buff->crid == crid) {
             uint64_t n_bistream_full_pages = len / RECONFIG_BUFF_PAGE_SIZE;
             uint64_t partial_bitsream_size = len % RECONFIG_BUFF_PAGE_SIZE;
+            if (n_bistream_full_pages + (partial_bitsream_size ? 1 : 0) > tmp_buff->n_pages) {
+                pr_warn("bitstream length %llu exceeds reconfig buffer of %u pages\n", len, tmp_buff->n_pages);
+                return -EINVAL;
+            }
             dbg_info(
                 "reconfig bitstream: full pages %lld (hugepages), partial %lld B\n", 
                 n_bistream_full_pages, partial_bitsream_size

--- a/driver/src/reconfig/reconfig_isr.c
+++ b/driver/src/reconfig/reconfig_isr.c
@@ -34,7 +34,7 @@ irqreturn_t reconfig_isr(int irq, void *dev) {
     // The FLAG_SET is picked up by IOCTL_RECONFIGURE_(SHELL|APP) in reconfig_ops.c
     dbg_info("(irq=%d) reconfig completed\n", irq);
     atomic_set(&device->wait_rcnfg, FLAG_SET);
-    wake_up_interruptible(&device->waitqueue_rcnfg);
+    wake_up(&device->waitqueue_rcnfg);
 
     // Clear IRQ by writing to memory-mapped register and unlock
     device->bd_data->stat_cnfg->reconfig_ctrl = RECONFIG_CTRL_IRQ_CLR_PENDING;

--- a/driver/src/reconfig/reconfig_mem.c
+++ b/driver/src/reconfig/reconfig_mem.c
@@ -115,32 +115,3 @@ fail_alloc:
     mutex_unlock(&device->mem_lock);
     return -ENOMEM;
 }
-
-int free_reconfig_buffer(struct reconfig_dev *device, uint64_t vaddr, pid_t pid, uint32_t crid) {
-    BUG_ON(!device);
-
-    // Iterate through metadata map of allocated buffers and free pages, delete map entry
-    struct reconfig_buff_metadata *tmp_buff;
-    hash_for_each_possible(reconfig_buffs_map, tmp_buff, entry, vaddr) {
-        if (tmp_buff->vaddr == vaddr && tmp_buff->pid == pid && tmp_buff->crid == crid) {
-            for (int i = 0; i < tmp_buff->n_pages; i++) {
-                if (tmp_buff->pages[i]) {
-                    dma_unmap_single(
-                        &device->bd_data->pci_dev->dev,
-                        tmp_buff->hpages[i],
-                        RECONFIG_BUFF_PAGE_SIZE,
-                        DMA_TO_DEVICE
-                    );
-                    __free_pages(tmp_buff->pages[i], RECONFIG_BUFF_PAGE_SHIFT - PAGE_SHIFT);
-                }
-            }
-            vfree(tmp_buff->pages);
-            vfree(tmp_buff->hpages);
-            hash_del(&tmp_buff->entry);
-        }
-    }
-
-    // NOTE: All the functions from above (__free_pages, vfree, hash_del are void)
-    // Therefore; there is no error handling, and hence, always return 0
-    return 0;
-}

--- a/driver/src/reconfig/reconfig_mem.c
+++ b/driver/src/reconfig/reconfig_mem.c
@@ -32,17 +32,16 @@ int alloc_reconfig_buffer(struct reconfig_dev *device, unsigned long n_pages, pi
     // Whenever buffers have been allocated and mapped, the variable n_pages is reset to 0
     // When different than zero, it means multiple allocations have occured but haven't been propagated to the user-space
     // Ideally, this should be prevented, as it means there are kernel-space allocated buffers that the user doesn't use
+    mutex_lock(&device->mem_lock);
     if (device->curr_buff.n_pages) {
+        mutex_unlock(&device->mem_lock);
         pr_warn("allocated reconfig buffers exist but have not been mapped\n");
         return -1;
     }
 
-    // Lock, preventing multiple simultaneous allocations
-    spin_lock(&device->mem_lock);
-
     if (n_pages > MAX_RECONFIG_BUFF_NUM) {
         dbg_info("requested reconfig buffer too large: %lu pages, max %d pages\n", n_pages, MAX_RECONFIG_BUFF_NUM); 
-        spin_unlock(&device->mem_lock); 
+        mutex_unlock(&device->mem_lock); 
         return -ENOMEM;
     } else {
         device->curr_buff.n_pages = n_pages;
@@ -52,6 +51,8 @@ int alloc_reconfig_buffer(struct reconfig_dev *device, unsigned long n_pages, pi
     device->curr_buff.pages = vmalloc(n_pages * sizeof(*device->curr_buff.pages));
     if (device->curr_buff.pages == NULL) {
         pr_warn("failed to allocate page pointer array for reconfig buffers");
+        device->curr_buff.n_pages = 0;
+        mutex_unlock(&device->mem_lock);
         return -ENOMEM;
     }
     dbg_info(
@@ -62,7 +63,7 @@ int alloc_reconfig_buffer(struct reconfig_dev *device, unsigned long n_pages, pi
     // Allocate the pages for this buffer
     int i;
     for (i = 0; i < device->curr_buff.n_pages; i++) {
-        device->curr_buff.pages[i] = alloc_pages(GFP_ATOMIC, RECONFIG_BUFF_PAGE_SHIFT - PAGE_SHIFT);
+        device->curr_buff.pages[i] = alloc_pages(GFP_KERNEL, RECONFIG_BUFF_PAGE_SHIFT - PAGE_SHIFT);
         if (!device->curr_buff.pages[i]) {
             pr_warn("reconfig buffer page %d could not be allocated\n", i);
             goto fail_alloc;
@@ -92,7 +93,7 @@ int alloc_reconfig_buffer(struct reconfig_dev *device, unsigned long n_pages, pi
 
     device->curr_buff.pid = pid;
     device->curr_buff.crid = crid;
-    spin_unlock(&device->mem_lock);
+    mutex_unlock(&device->mem_lock);
     return 0;
 
 fail_dma_map:
@@ -111,7 +112,7 @@ fail_alloc:
     device->curr_buff.n_pages = 0;
     vfree(device->curr_buff.pages);
 
-    spin_unlock(&device->mem_lock);
+    mutex_unlock(&device->mem_lock);
     return -ENOMEM;
 }
 

--- a/driver/src/reconfig/reconfig_ops.c
+++ b/driver/src/reconfig/reconfig_ops.c
@@ -231,7 +231,7 @@ int reconfig_dev_mmap(struct file *file, struct vm_area_struct *vma) {
 
         // Check pages have been allocated and the current process was the one that allocated them 
         if (device->curr_buff.n_pages != 0 && device->curr_buff.pid == current->pid) {
-            spin_lock(&device->mem_lock);
+            mutex_lock(&device->mem_lock);
 
             // Store metadata about the recently allocated buffer to the map (reconfig_buffs_map)
             struct reconfig_buff_metadata *new_buff = kzalloc(sizeof(struct reconfig_buff_metadata), GFP_KERNEL);
@@ -252,6 +252,9 @@ int reconfig_dev_mmap(struct file *file, struct vm_area_struct *vma) {
                         page_to_pfn(device->curr_buff.pages[i]), RECONFIG_BUFF_PAGE_SIZE, vma->vm_page_prot)
                     ) {
                         pr_warn("failed to remap, virtual address 0x%llx\n", virtual_address_tmp);
+                        hash_del(&new_buff->entry);
+                        kfree(new_buff);
+                        mutex_unlock(&device->mem_lock);
                         return -EIO;
                     }
                 virtual_address_tmp += RECONFIG_BUFF_PAGE_SIZE;
@@ -260,7 +263,7 @@ int reconfig_dev_mmap(struct file *file, struct vm_area_struct *vma) {
             // Mark current buff as empty, to allo future mmaps (see first if in this function)
             device->curr_buff.n_pages = 0;
 
-            spin_unlock(&device->mem_lock);
+            mutex_unlock(&device->mem_lock);
             dbg_info("reconfig device, completed mmap\n");
             return 0;
         }

--- a/driver/src/reconfig/reconfig_ops.c
+++ b/driver/src/reconfig/reconfig_ops.c
@@ -118,10 +118,13 @@ long reconfig_dev_ioctl(struct file *file, unsigned int command, unsigned long a
                 ret_val = reconfigure_start(device, tmp[0], tmp[1], tmp[2], tmp[3]);
                 if (ret_val != 0) {
                     pr_warn("shell reconfiguration not successful, return %d\n", ret_val);
+                    bus_data->stat_cnfg->reconfig_dcpl_clr = 0x1;
+                    shell_pci_init(bus_data);
+                    mutex_unlock(&device->rcnfg_lock);
                     return -1;
                 }
 
-                wait_event_interruptible(device->waitqueue_rcnfg, atomic_read(&device->wait_rcnfg) == FLAG_SET);
+                wait_event(device->waitqueue_rcnfg, atomic_read(&device->wait_rcnfg) == FLAG_SET);
                 atomic_set(&device->wait_rcnfg, FLAG_CLR);
 
                 // Reset end-of-start up time (active-low)
@@ -166,15 +169,17 @@ long reconfig_dev_ioctl(struct file *file, unsigned int command, unsigned long a
                 ret_val = reconfigure_start(device, tmp[0], tmp[1], tmp[2], tmp[3]);
                 if (ret_val != 0) {
                     pr_warn("app reconfiguration not successful, return %d\n", ret_val);
+                    bus_data->shell_cnfg->reconfig_dcpl_app_clr = (1 << (uint32_t) tmp[4]);
+                    mutex_unlock(&device->rcnfg_lock);
                     return -1;
                 }
 
-                wait_event_interruptible(device->waitqueue_rcnfg, atomic_read(&device->wait_rcnfg) == FLAG_SET);
+                wait_event(device->waitqueue_rcnfg, atomic_read(&device->wait_rcnfg) == FLAG_SET);
                 atomic_set(&device->wait_rcnfg, FLAG_CLR);
 
                 // Couple and unlock mutex
                 dbg_info("app reconfiguration complete, coupling the design and unlocking mutex\n");
-                bus_data->shell_cnfg->reconfig_dcpl_app_clr = (1 << (uint32_t)tmp[3]);
+                bus_data->shell_cnfg->reconfig_dcpl_app_clr = (1 << (uint32_t) tmp[4]);
                 mutex_unlock(&device->rcnfg_lock);
 
                 uint64_t stop_time = ktime_get_ns();

--- a/driver/src/reconfig/reconfig_ops.c
+++ b/driver/src/reconfig/reconfig_ops.c
@@ -83,9 +83,8 @@ long reconfig_dev_ioctl(struct file *file, unsigned int command, unsigned long a
                 pr_warn("user data could not be coppied, return %d\n", ret_val);
             }
             else {
-                // NOTE: free_reconfig_buffer always returns zero; hence no error handling
-                ret_val = free_reconfig_buffer(device, tmp[0], tmp[1], tmp[2]);
-                dbg_info("reconfig buffer freed, virtual address 0x%lx\n", tmp[0]);
+                // Pages are owned by the mapping and released on munmap()
+                dbg_info("reconfig buffer free requested, virtual address 0x%lx\n", tmp[0]);
             }
             break;
 
@@ -220,59 +219,113 @@ long reconfig_dev_ioctl(struct file *file, unsigned int command, unsigned long a
     return ret_val;
 }
 
+static void reconfig_buff_release(struct reconfig_dev *device, struct reconfig_buff_metadata *buff) {
+    for (int i = 0; i < buff->n_pages; i++) {
+        dma_unmap_single(&device->bd_data->pci_dev->dev, buff->hpages[i], RECONFIG_BUFF_PAGE_SIZE, DMA_TO_DEVICE);
+        __free_pages(buff->pages[i], RECONFIG_BUFF_PAGE_SHIFT - PAGE_SHIFT);
+    }
+    vfree(buff->pages);
+    vfree(buff->hpages);
+    kfree(buff);
+}
+
+static void reconfig_vma_open(struct vm_area_struct *vma) {
+    // VM_DONTCOPY prevents fork() from duplicating the mapping; nothing to do
+}
+
+static void reconfig_vma_close(struct vm_area_struct *vma) {
+    struct reconfig_buff_metadata *buff = vma->vm_private_data;
+    struct reconfig_dev *device = buff->device;
+
+    mutex_lock(&device->rcnfg_lock);
+    mutex_lock(&device->mem_lock);
+    hash_del(&buff->entry);
+    mutex_unlock(&device->mem_lock);
+    mutex_unlock(&device->rcnfg_lock);
+
+    reconfig_buff_release(device, buff);
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+static int reconfig_vma_may_split(struct vm_area_struct *vma, unsigned long addr) {
+    return -EINVAL;
+}
+#endif
+
+static const struct vm_operations_struct reconfig_vm_ops = {
+    .open = reconfig_vma_open,
+    .close = reconfig_vma_close,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+    .may_split = reconfig_vma_may_split,
+#endif
+};
+
 int reconfig_dev_mmap(struct file *file, struct vm_area_struct *vma) {
-    // Parse device attributes
     struct reconfig_dev *device = (struct reconfig_dev *) file->private_data;
     BUG_ON(!device);
+
+    if (vma->vm_pgoff != MMAP_RECONFIG)
+        return -EINVAL;
 
     // Map previously allocated reconfiguration buffers to user-space
     // Buffers must have been allocated using IOCTL_ALLOC_HOST_RECONFIG_MEM
     vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
-    if (vma->vm_pgoff == MMAP_RECONFIG) {
-        dbg_info("reconfig device, starting mmap\n");
+    dbg_info("reconfig device, starting mmap\n");
 
-        // Align virtual address (vma->vm_start) to page boundary
-        uint64_t vaddr = ((vma->vm_start + RECONFIG_BUFF_PAGE_SIZE - 1) >> RECONFIG_BUFF_PAGE_SHIFT) << RECONFIG_BUFF_PAGE_SHIFT;
+    // Align virtual address (vma->vm_start) to page boundary
+    uint64_t vaddr = ((vma->vm_start + RECONFIG_BUFF_PAGE_SIZE - 1) >> RECONFIG_BUFF_PAGE_SHIFT) << RECONFIG_BUFF_PAGE_SHIFT;
 
-        // Check pages have been allocated and the current process was the one that allocated them 
-        if (device->curr_buff.n_pages != 0 && device->curr_buff.pid == current->pid) {
-            mutex_lock(&device->mem_lock);
+    mutex_lock(&device->mem_lock);
 
-            // Store metadata about the recently allocated buffer to the map (reconfig_buffs_map)
-            struct reconfig_buff_metadata *new_buff = kzalloc(sizeof(struct reconfig_buff_metadata), GFP_KERNEL);
-            BUG_ON(!new_buff);
-            new_buff->vaddr = vaddr;
-            new_buff->pid = current->pid;
-            new_buff->crid = device->curr_buff.crid;
-            new_buff->n_pages = device->curr_buff.n_pages;
-            new_buff->pages = device->curr_buff.pages;
-            new_buff->hpages = device->curr_buff.hpages;
-            hash_add(reconfig_buffs_map, &new_buff->entry, vaddr);
-            
-            // Remap each page to user-space
-            uint64_t virtual_address_tmp = vaddr;
-            for (int i = 0; i < new_buff->n_pages; i++) {
-                if (remap_pfn_range(
-                        vma, virtual_address_tmp, 
-                        page_to_pfn(device->curr_buff.pages[i]), RECONFIG_BUFF_PAGE_SIZE, vma->vm_page_prot)
-                    ) {
-                        pr_warn("failed to remap, virtual address 0x%llx\n", virtual_address_tmp);
-                        hash_del(&new_buff->entry);
-                        kfree(new_buff);
-                        mutex_unlock(&device->mem_lock);
-                        return -EIO;
-                    }
-                virtual_address_tmp += RECONFIG_BUFF_PAGE_SIZE;
-            }
-
-            // Mark current buff as empty, to allo future mmaps (see first if in this function)
-            device->curr_buff.n_pages = 0;
-
-            mutex_unlock(&device->mem_lock);
-            dbg_info("reconfig device, completed mmap\n");
-            return 0;
-        }
+    // Check pages have been allocated and the current process was the one that allocated them
+    if (device->curr_buff.n_pages == 0 || device->curr_buff.pid != current->pid) {
+        mutex_unlock(&device->mem_lock);
+        return -EINVAL;
     }
 
-    return -EINVAL;
+    if (vaddr + (uint64_t) device->curr_buff.n_pages * RECONFIG_BUFF_PAGE_SIZE > vma->vm_end) {
+        mutex_unlock(&device->mem_lock);
+        pr_warn("mmap of %lu bytes too small for %u reconfig pages\n", vma->vm_end - vma->vm_start, device->curr_buff.n_pages);
+        return -EINVAL;
+    }
+
+    struct reconfig_buff_metadata *new_buff = kzalloc(sizeof(struct reconfig_buff_metadata), GFP_KERNEL);
+    if (!new_buff) {
+        mutex_unlock(&device->mem_lock);
+        return -ENOMEM;
+    }
+    new_buff->device = device;
+    new_buff->vaddr = vaddr;
+    new_buff->pid = current->pid;
+    new_buff->crid = device->curr_buff.crid;
+    new_buff->n_pages = device->curr_buff.n_pages;
+    new_buff->pages = device->curr_buff.pages;
+    new_buff->hpages = device->curr_buff.hpages;
+
+    // Remap each page to user-space
+    uint64_t virtual_address_tmp = vaddr;
+    for (int i = 0; i < new_buff->n_pages; i++) {
+        if (remap_pfn_range(vma, virtual_address_tmp, page_to_pfn(new_buff->pages[i]), RECONFIG_BUFF_PAGE_SIZE, vma->vm_page_prot)) {
+            pr_warn("failed to remap, virtual address 0x%llx\n", virtual_address_tmp);
+            kfree(new_buff);
+            mutex_unlock(&device->mem_lock);
+            return -EIO;
+        }
+        virtual_address_tmp += RECONFIG_BUFF_PAGE_SIZE;
+    }
+
+    // The mapping now owns the pages; they are released in reconfig_vma_close()
+    device->curr_buff.n_pages = 0;
+    hash_add(reconfig_buffs_map, &new_buff->entry, vaddr);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+    vm_flags_set(vma, VM_DONTCOPY | VM_DONTEXPAND);
+#else
+    vma->vm_flags |= VM_DONTCOPY | VM_DONTEXPAND;
+#endif
+    vma->vm_private_data = new_buff;
+    vma->vm_ops = &reconfig_vm_ops;
+
+    mutex_unlock(&device->mem_lock);
+    dbg_info("reconfig device, completed mmap\n");
+    return 0;
 }

--- a/driver/src/vfpga/vfpga_gup.c
+++ b/driver/src/vfpga/vfpga_gup.c
@@ -545,8 +545,9 @@ int tlb_put_user_pages(struct vfpga_dev *device, uint64_t vaddr, int32_t ctid, p
     uint64_t vaddr_tmp = (vaddr & bd_data->stlb_meta->page_mask) >> bd_data->stlb_meta->page_shift;
 
     struct user_pages *tmp_entry;
-    hash_for_each_possible(user_buff_map[device->id][ctid], tmp_entry, entry, vaddr_tmp) {
-        if(vaddr_tmp >= tmp_entry->vaddr && vaddr_tmp <= tmp_entry->vaddr + tmp_entry->n_pages) {
+    struct hlist_node *tmp_next;
+    hash_for_each_possible_safe(user_buff_map[device->id][ctid], tmp_entry, tmp_next, entry, vaddr_tmp) {
+        if(vaddr_tmp >= tmp_entry->vaddr && vaddr_tmp < tmp_entry->vaddr + tmp_entry->n_pages) {
             // Unmap from TLB
             tlb_unmap_gup(device, tmp_entry, hpid);
 
@@ -606,6 +607,7 @@ int tlb_put_user_pages(struct vfpga_dev *device, uint64_t vaddr, int32_t ctid, p
 
             // Remove from map
             hash_del(&tmp_entry->entry);
+            kfree(tmp_entry);
         }
     }
 
@@ -615,12 +617,13 @@ int tlb_put_user_pages(struct vfpga_dev *device, uint64_t vaddr, int32_t ctid, p
 int tlb_put_user_pages_ctid(struct vfpga_dev *device, int32_t ctid, pid_t hpid, int dirtied) {
     int i, bkt;
     struct user_pages *tmp_entry;
+    struct hlist_node *tmp_next;
 
     BUG_ON(!device);
     struct bus_driver_data *bd_data = device->bd_data;
     BUG_ON(!bd_data);
 
-    hash_for_each(user_buff_map[device->id][ctid], bkt, tmp_entry, entry) {
+    hash_for_each_safe(user_buff_map[device->id][ctid], bkt, tmp_next, tmp_entry, entry) {
         // Unmap from TLB
         tlb_unmap_gup(device, tmp_entry, hpid);
         
@@ -680,6 +683,7 @@ int tlb_put_user_pages_ctid(struct vfpga_dev *device, int32_t ctid, pid_t hpid, 
 
         // Remove from map
         hash_del(&tmp_entry->entry);
+        kfree(tmp_entry);
     }
 
     return 0;
@@ -806,7 +810,7 @@ void p2p_move_notify(struct dma_buf_attachment *attach) {
     struct user_pages *tmp_entry;
 
     hash_for_each_possible(user_buff_map[device->id][ctid], tmp_entry, entry, vaddr_tmp) {
-        if(vaddr_tmp >= tmp_entry->vaddr && vaddr_tmp <= tmp_entry->vaddr + tmp_entry->n_pages) {
+        if(vaddr_tmp >= tmp_entry->vaddr && vaddr_tmp < tmp_entry->vaddr + tmp_entry->n_pages) {
             // Unmap any previous entry from TLB
             tlb_unmap_gup(device, tmp_entry, hpid);
 
@@ -1022,8 +1026,9 @@ int p2p_detach_dma_buf(struct vfpga_dev *device, uint64_t vaddr, int32_t ctid, i
     pid_t hpid = device->pid_array[ctid];
 
     struct user_pages *tmp_entry;
-    hash_for_each_possible(user_buff_map[device->id][ctid], tmp_entry, entry, vaddr_tmp) {
-        if(vaddr_tmp >= tmp_entry->vaddr && vaddr_tmp <= tmp_entry->vaddr + tmp_entry->n_pages) {
+    struct hlist_node *tmp_next;
+    hash_for_each_possible_safe(user_buff_map[device->id][ctid], tmp_entry, tmp_next, entry, vaddr_tmp) {
+        if(vaddr_tmp >= tmp_entry->vaddr && vaddr_tmp < tmp_entry->vaddr + tmp_entry->n_pages) {
             // Unmap from TLB
             tlb_unmap_gup(device, tmp_entry, hpid);
         
@@ -1050,6 +1055,7 @@ int p2p_detach_dma_buf(struct vfpga_dev *device, uint64_t vaddr, int32_t ctid, i
             
             // Remove from map
             hash_del(&tmp_entry->entry);
+            kfree(tmp_entry);
         }
     }
     

--- a/driver/src/vfpga/vfpga_gup.c
+++ b/driver/src/vfpga/vfpga_gup.c
@@ -257,8 +257,8 @@ void tlb_unmap_gup(struct vfpga_dev *device, struct user_pages *user_pg, pid_t h
         vaddr_tmp += pg_inc;
     }
 
-    // Wait for completion
-    wait_event_interruptible(device->waitqueue_invldt, atomic_read(&device->wait_invldt) == FLAG_SET);
+    // Not interruptible: callers unpin the pages right after this returns
+    wait_event(device->waitqueue_invldt, atomic_read(&device->wait_invldt) == FLAG_SET);
     atomic_set(&device->wait_invldt, FLAG_CLR);
 }
 
@@ -667,7 +667,7 @@ void migrate_to_card(struct vfpga_dev *device, struct user_pages *user_pg) {
 
     trigger_dma_offload(device, user_pg->hpages, user_pg->cpages, user_pg->n_pages, user_pg->huge);
     
-    wait_event_interruptible(device->waitqueue_offload, atomic_read(&device->wait_offload) == FLAG_SET);
+    wait_event(device->waitqueue_offload, atomic_read(&device->wait_offload) == FLAG_SET);
     atomic_set(&device->wait_offload, FLAG_CLR);
 
     mutex_unlock(&device->offload_lock);
@@ -678,7 +678,7 @@ void migrate_to_host(struct vfpga_dev *device, struct user_pages *user_pg) {
 
     trigger_dma_sync(device, user_pg->hpages, user_pg->cpages, user_pg->n_pages, user_pg->huge);
     
-    wait_event_interruptible(device->waitqueue_sync, atomic_read(&device->wait_sync) == FLAG_SET);
+    wait_event(device->waitqueue_sync, atomic_read(&device->wait_sync) == FLAG_SET);
     atomic_set(&device->wait_sync, FLAG_CLR);
 
     mutex_unlock(&device->sync_lock);

--- a/driver/src/vfpga/vfpga_gup.c
+++ b/driver/src/vfpga/vfpga_gup.c
@@ -376,12 +376,8 @@ struct user_pages* tlb_get_user_pages(struct vfpga_dev *device, struct pf_aligne
             // However, in some cases (e.g., migrating data between the host and FPGA memory)
             // Coyote still needs all the entries in the hpages array; since the transfers
             // are issued in 4k granularity from the driver
-            for (int j = i + 1; j < i + device->bd_data->n_pages_in_huge; j++) {
+            for (int j = i + 1; j < i + device->bd_data->n_pages_in_huge && j < pf_desc->n_pages; j++) {
                 user_pg->hpages[j] = user_pg->hpages[i] + (j - i) * PAGE_SIZE;
-
-                if (j >= pf_desc->n_pages) {
-                    break;
-                }
             }
 
         }

--- a/driver/src/vfpga/vfpga_gup.c
+++ b/driver/src/vfpga/vfpga_gup.c
@@ -30,13 +30,28 @@ int mmu_handler_gup(struct vfpga_dev *device, uint64_t vaddr, uint64_t len, int3
     struct bus_driver_data *bd_data = device->bd_data;
 
     // Find context (host process ID)
-    struct task_struct *curr_task = pid_task(find_vpid(hpid), PIDTYPE_PID);
+    struct task_struct *curr_task = get_pid_task(find_vpid(hpid), PIDTYPE_PID);
+    if (!curr_task) {
+        pr_err("hpid %d not found\n", hpid);
+        return -ESRCH;
+    }
     dbg_info("hpid found = %d", hpid);
-    struct mm_struct *curr_mm = curr_task->mm;
+    struct mm_struct *curr_mm = get_task_mm(curr_task);
+    if (!curr_mm) {
+        put_task_struct(curr_task);
+        return -ESRCH;
+    }
 
     // Check if the request area is huge page or not
+    mmap_read_lock(curr_mm);
     struct vm_area_struct *vma_area_init = find_vma(curr_mm, vaddr);
+    if (!vma_area_init || vaddr < vma_area_init->vm_start) {
+        mmap_read_unlock(curr_mm);
+        ret_val = -EFAULT;
+        goto out;
+    }
     int hugepages = is_vm_hugetlb_page(vma_area_init);
+    mmap_read_unlock(curr_mm);
     struct tlb_metadata *tlb_meta = hugepages ? bd_data->ltlb_meta : bd_data->stlb_meta;
 
     // Align to a page boundary and calculate the number of pages bust on the buffer lenght (in bytes)
@@ -89,7 +104,8 @@ int mmu_handler_gup(struct vfpga_dev *device, uint64_t vaddr, uint64_t len, int3
         user_pg = tlb_get_user_pages(device, &pf_desc, hpid, curr_task, curr_mm, mem_block);
         if(!user_pg) {
             pr_err("user pages could not be obtained\n");
-            return -ENOMEM;
+            ret_val = -ENOMEM;
+            goto out;
         }
 
         // In case there are caching effects, return a non-zero code to the user space
@@ -108,6 +124,9 @@ int mmu_handler_gup(struct vfpga_dev *device, uint64_t vaddr, uint64_t len, int3
         }
     }
 
+out:
+    mmput(curr_mm);
+    put_task_struct(curr_task);
     return ret_val;
 }
 
@@ -297,6 +316,7 @@ struct user_pages* tlb_get_user_pages(struct vfpga_dev *device, struct pf_aligne
     // Pin the pages
     // On newer kernels, pin_user_pages_remote is preferred over get_user_pages_remote for DMA,
     // as it guarantees that the pages remain pinned (and not just the page struct) until explicitly unpinned
+    mmap_read_lock(curr_mm);
     #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
         ret_val = pin_user_pages_remote(curr_mm, (unsigned long) pf_desc->vaddr << PAGE_SHIFT, pf_desc->n_pages, FOLL_WRITE | FOLL_LONGTERM, user_pg->pages, NULL);
     #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
@@ -306,12 +326,15 @@ struct user_pages* tlb_get_user_pages(struct vfpga_dev *device, struct pf_aligne
     #else
         ret_val = get_user_pages_remote(curr_task, curr_mm, (unsigned long) pf_desc->vaddr << PAGE_SHIFT, pf_desc->n_pages, 1, user_pg->pages, NULL, NULL);
     #endif
-    dbg_info("pin_user_pages_remote(%llx, n_pages = %d, page start = %lx, hugepages = %d)\n", pf_desc->vaddr, pf_desc->n_pages, page_to_pfn(user_pg->pages[0]), pf_desc->hugepages);
+    mmap_read_unlock(curr_mm);
 
-    if (ret_val < pf_desc->n_pages) {
+    if (ret_val < 0 || ret_val < pf_desc->n_pages) {
         pr_warn("could not get all user pages, %d\n", ret_val);
+        if (ret_val < 0)
+            ret_val = 0;
         goto fail_host_alloc;
     }
+    dbg_info("pin_user_pages_remote(%llx, n_pages = %d, page start = %lx, hugepages = %d)\n", pf_desc->vaddr, pf_desc->n_pages, page_to_pfn(user_pg->pages[0]), pf_desc->hugepages);
 
     // Flush cache
     for (int i = 0; i < pf_desc->n_pages; i++) {

--- a/driver/src/vfpga/vfpga_hw.c
+++ b/driver/src/vfpga/vfpga_hw.c
@@ -229,6 +229,7 @@ int alloc_card_memory(struct vfpga_dev *device, uint64_t *card_physical_address,
     if (huge) {
         // Check sufficient space is available 
         if (bus_data->card_lblocks[target_block].free_chunks < n_pages) {
+            spin_unlock(&bus_data->card_lock);
             pr_warn("insufficient memory on card to store buffer\n");
             return -ENOMEM;
         }
@@ -244,6 +245,7 @@ int alloc_card_memory(struct vfpga_dev *device, uint64_t *card_physical_address,
     } else {
         // Check sufficient space in card memory is available 
         if (bus_data->card_sblocks[target_block].free_chunks < n_pages) {
+            spin_unlock(&bus_data->card_lock);
             pr_warn("insufficient memory on card to store buffer\n");
             return -ENOMEM;
         }

--- a/driver/src/vfpga/vfpga_isr.c
+++ b/driver/src/vfpga/vfpga_isr.c
@@ -110,13 +110,19 @@ void vfpga_notify_handler(struct work_struct *work) {
     // Mutex, preventing multiple simultaneous user interrupts (notifications)
     // Typically, the hardware can issue interrupts faster than the software can process them; therefore a mutex (to prevent some interrupts being dropped)
     // In case the notification cannot be parsed, the mutex is unlocked immediately; otherwise it's unlocked form the user-space via IOCTL_SET_NOTIFICATION_PROCESSED
-    mutex_lock(&user_notifier_lock[device->id][irq_not->ctid]);
+    if (irq_not->ctid < 0 || irq_not->ctid >= N_CTID_MAX) {
+        pr_warn("dropped notify event with invalid ctid %d\n", irq_not->ctid);
+        kfree(irq_not);
+        return;
+    }
+
+    down(&user_notifier_lock[device->id][irq_not->ctid]);
     dbg_info("notify vFPGA %d, notification value %d, ctid %d\n", device->id, irq_not->notification_value, irq_not->ctid);
 
     // Check an eventfd exists for this vFPGA and Coyote thread (must have been registered using vfpga_register_eventfd(...))
     if (!user_notifier[device->id][irq_not->ctid]) {
         pr_warn("dropped notify event because there is no recpient\n");
-        mutex_unlock(&user_notifier_lock[device->id][irq_not->ctid]);
+        up(&user_notifier_lock[device->id][irq_not->ctid]);
         kfree(irq_not);
         return;
     }
@@ -147,7 +153,7 @@ void vfpga_notify_handler(struct work_struct *work) {
 
     if (ret_val != 1) {
         pr_warn("could not signal eventfd\n");
-        mutex_unlock(&user_notifier_lock[device->id][irq_not->ctid]);
+        up(&user_notifier_lock[device->id][irq_not->ctid]);
     }
 
     kfree(irq_not);
@@ -159,6 +165,12 @@ void vfpga_pfault_handler(struct work_struct *work) {
     BUG_ON(!irq_pf);
     struct vfpga_dev *device = irq_pf->device;
     BUG_ON(!device);
+
+    if (irq_pf->ctid < 0 || irq_pf->ctid >= N_CTID_MAX) {
+        pr_err("page fault with invalid ctid %d, vFPGA %d\n", irq_pf->ctid, device->id);
+        kfree(irq_pf);
+        return;
+    }
 
     mutex_lock(&device->mmu_lock);
     pid_t hpid = device->pid_array[irq_pf->ctid];

--- a/driver/src/vfpga/vfpga_isr.c
+++ b/driver/src/vfpga/vfpga_isr.c
@@ -38,21 +38,21 @@ irqreturn_t vfpga_isr(int irq, void *d) {
             // vFPGA completed DMA off-load, set the correct flag (which is being polled on in the memory handler (HMM/GUP))
             dbg_info("(irq=%d) DMA offload completed, vFPGA %d\n", irq, device->id);
             atomic_set(&device->wait_offload, FLAG_SET);
-            wake_up_interruptible(&device->waitqueue_offload);
+            wake_up(&device->waitqueue_offload);
             break;
 
         case IRQ_DMA_SYNC:
             // vFPGA completed DMA sync, set the correct flag (which is being polled on in the memory handler (HMM/GUP))
             dbg_info("(irq=%d) DMA sync completed, vFPGA %d\n", irq, device->id);
             atomic_set(&device->wait_sync, FLAG_SET);
-            wake_up_interruptible(&device->waitqueue_sync);
+            wake_up(&device->waitqueue_sync);
             break;
 
         case IRQ_INVLDT: 
             // vFPGA completed invalidation, set the correct flag (which is being polled on in the memory handler (HMM/GUP))
             dbg_info("(irq=%d) invalidation completed, vFPGA %d\n", irq, device->id);
             atomic_set(&device->wait_invldt, FLAG_SET);
-            wake_up_interruptible(&device->waitqueue_invldt);
+            wake_up(&device->waitqueue_invldt);
             break;
 
         case IRQ_PFAULT:

--- a/driver/src/vfpga/vfpga_ops.c
+++ b/driver/src/vfpga/vfpga_ops.c
@@ -39,7 +39,9 @@ int vfpga_dev_open(struct inode *inode, struct file *file) {
 
     // Set file private data, so the attributes of the opened vfpga_dev can be accessed in other methods
     file->private_data = (void *) device;
+    mutex_lock(&device->pid_lock);
     device->ref_cnt++;
+    mutex_unlock(&device->pid_lock);
 
     return 0;
 }
@@ -54,8 +56,11 @@ int vfpga_dev_release(struct inode *inode, struct file *file) {
     BUG_ON(!device);
 
     // Traverse all Coyote threads for this vFPGA device and free their resources
+    mutex_lock(&device->pid_lock);
     if(--device->ref_cnt == 0) {
-        hash_for_each(hpid_ctid_map[device->id], bkt, tmp_h_entry, entry) {
+        struct hlist_node *tmp_h_next;
+        mutex_lock(&device->mmu_lock);
+        hash_for_each_safe(hpid_ctid_map[device->id], bkt, tmp_h_next, tmp_h_entry, entry) {
             list_for_each_safe(l_p, l_n, &tmp_h_entry->ctid_list) {
                 // entry
                 struct ctid_entry *l_entry = list_entry(l_p, struct ctid_entry, list);
@@ -73,28 +78,31 @@ int vfpga_dev_release(struct inode *inode, struct file *file) {
                 device->pid_alloc = &device->ctid_chunks[l_entry->ctid];
 
                 // Delete entry
-                list_del(&l_entry->list); 
-
-                // Remove notifier and entry if all cThreads for this HPID are gone
-                if(list_empty(&tmp_h_entry->ctid_list)) {
-                    #ifdef HMM_KERNEL                        
-                        // remove notifier
-                        if(en_hmm) {
-                            dbg_info("releasing notifier for hpid %d\n", tmp_h_entry->hpid);
-                            mmu_interval_notifier_remove(&tmp_h_entry->mmu_not);
-                        }
-                    #endif 
-
-                    hash_del(&tmp_h_entry->entry);
-                }
+                list_del(&l_entry->list);
+                kfree(l_entry);
             }
+
+            #ifdef HMM_KERNEL
+                if(en_hmm) {
+                    dbg_info("releasing notifier for hpid %d\n", tmp_h_entry->hpid);
+                    mmu_interval_notifier_remove(&tmp_h_entry->mmu_not);
+                }
+            #endif
+            hash_del(&tmp_h_entry->entry);
+            kfree(tmp_h_entry);
         }
+        mutex_unlock(&device->mmu_lock);
     }
+    mutex_unlock(&device->pid_lock);
     
     int minor = iminor(inode);
     dbg_info("vFPGA device %d released, spid %d, ref cnt %d\n", minor, current->pid, device->ref_cnt);
 
     return 0;
+}
+
+static bool ctid_valid(uint64_t ctid) {
+    return ctid < N_CTID_MAX;
 }
 
 long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg) {
@@ -133,7 +141,7 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
                 pid_t hpid = (pid_t) tmp[0];
 
                 // Check if a new Coyote thread can be registered
-                if (device->num_free_ctid_chunks == 0) {
+                if (!device->pid_alloc) {
                     dbg_info("no free ctid chunks left for hpid %d, spid %d\n", hpid, spid);
                     mutex_unlock(&device->pid_lock);
                     return -ENOMEM;
@@ -169,6 +177,7 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
                             if (ret_val) {
                                 dbg_info("mmu notifier registration failed, vFPGA %d\n", device->id);
                                 kfree(new_h_entry);
+                                mutex_unlock(&device->pid_lock);
                                 return ret_val;
                             } 
                         }
@@ -207,6 +216,8 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
             if (ret_val != 0) {
                 pr_warn("user data could not be coppied, return %d\n", ret_val);
             } else {
+                if (!ctid_valid(tmp[0]))
+                    return -EINVAL;
                 mutex_lock(&device->pid_lock);
                 
                 int32_t ctid = (int32_t) tmp[0];
@@ -214,28 +225,32 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
                 pid_t spid = current->pid;
             
                 struct hpid_ctid_pages *tmp_h_entry;
+                struct hlist_node *tmp_h_next;
                 struct list_head *l_p, *l_n;
                 struct ctid_entry *l_entry;
 
                 // Traverse all Coyote thread IDs until a match is found
-                hash_for_each_possible(hpid_ctid_map[device->id], tmp_h_entry, entry, hpid) {
+                hash_for_each_possible_safe(hpid_ctid_map[device->id], tmp_h_entry, tmp_h_next, entry, hpid) {
                     if(tmp_h_entry->hpid == hpid) {
                         list_for_each_safe(l_p, l_n, &tmp_h_entry->ctid_list) {
                             l_entry = list_entry(l_p, struct ctid_entry, list);
 
                             if(l_entry->ctid == ctid) {
                                 // Unmap any leftover user pages for this Coyot thread
+                                mutex_lock(&device->mmu_lock);
                                 #ifdef HMM_KERNEL
                                     if(en_hmm)
                                         free_card_mem(device, ctid);
                                     else 
                                 #endif                            
                                     tlb_put_user_pages_ctid(device, ctid, hpid, 1);
+                                mutex_unlock(&device->mmu_lock);
 
                                 // Unregister Coyote thread and delete entry from list
                                 device->ctid_chunks[l_entry->ctid].next = device->pid_alloc;
                                 device->pid_alloc = &device->ctid_chunks[l_entry->ctid];
-                                list_del(&l_entry->list);   
+                                list_del(&l_entry->list);
+                                kfree(l_entry);
                             }
                         }
 
@@ -248,6 +263,7 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
                                 }
                             #endif 
                             hash_del(&tmp_h_entry->entry);
+                            kfree(tmp_h_entry);
                         }
                     }
                 }
@@ -266,6 +282,8 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
             if (ret_val) {
                 pr_warn("user data could not be coppied, ret_val: %d\n", ret_val);
             } else {
+                if (!ctid_valid(tmp[0]))
+                    return -EINVAL;
                 ret_val = vfpga_register_eventfd(device, (int32_t) tmp[0], tmp[1]);
                 if (ret_val) {
                     dbg_info("eventfd could not be registered, ret_val: %d\n", ret_val);
@@ -280,6 +298,8 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
             if (ret_val) {
                 pr_warn("user data could not be coppied, ret_val: %d\n", ret_val);
             } else {
+                if (!ctid_valid(tmp[0]))
+                    return -EINVAL;
                 vfpga_unregister_eventfd(device, (int32_t) tmp[0]);
             }
             break;
@@ -291,6 +311,8 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
             if (ret_val != 0) {
                 pr_warn("user data could not be coppied, return %d\n", ret_val);
             } else {
+                if (!ctid_valid(tmp[2]))
+                    return -EINVAL;
                 int32_t ctid = (int32_t)tmp[2];
                 pid_t hpid = device->pid_array[ctid];
 
@@ -324,6 +346,8 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
                 pr_warn("user data could not be coppied, return %d\n", ret_val);
             } else {
                 if(!en_hmm) {
+                    if (!ctid_valid(tmp[1]))
+                        return -EINVAL;
                     int32_t ctid = (int32_t) tmp[1];
                     pid_t hpid = device->pid_array[ctid];
 
@@ -346,6 +370,8 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
                 if (ret_val != 0) {
                     pr_warn("user data could not be coppied, return %d\n", ret_val);
                 } else {
+                    if (!ctid_valid(tmp[2]))
+                        return -EINVAL;
                     int32_t ctid = (int32_t) tmp[2];
 
                     dbg_info("mapping dmabuff for vFPGA %d, fd %d, virtual address %llx, ctid %d\n", device->id, (int) tmp[0], tmp[1], ctid);
@@ -377,6 +403,8 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
                     pr_warn("user data could not be coppied, return %d\n", ret_val);
                 } else {
                     if(!en_hmm) {
+                        if (!ctid_valid(tmp[1]))
+                            return -EINVAL;
                         int32_t ctid = (int32_t) tmp[1];
 
                         dbg_info("unmapping dmabuff for vFPGA %d, ctid %d\n", device->id, ctid);
@@ -407,7 +435,13 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
                 pr_warn("user data could not be coppied, return %d\n", ret_val);
             } else {
                 if(!en_hmm) {
+                    if (!ctid_valid(tmp[2]))
+                        return -EINVAL;
+                    mutex_lock(&device->mmu_lock);
+                    change_tlb_lock(device);
                     ret_val = offload_user_pages(device, tmp[0], (uint32_t) tmp[1], (int32_t) tmp[2]);
+                    change_tlb_lock(device);
+                    mutex_unlock(&device->mmu_lock);
                     if(ret_val) {
                         dbg_info("buffer could not be offloaded, ret_val: %d\n", ret_val);
                     }
@@ -428,7 +462,13 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
                 pr_warn("user data could not be coppied, return %d\n", ret_val);
             } else {
                 if(!en_hmm) {
+                    if (!ctid_valid(tmp[2]))
+                        return -EINVAL;
+                    mutex_lock(&device->mmu_lock);
+                    change_tlb_lock(device);
                     ret_val = sync_user_pages(device, tmp[0], (uint32_t) tmp[1], (int32_t) tmp[2]);
+                    change_tlb_lock(device);
+                    mutex_unlock(&device->mmu_lock);
                     if (ret_val) {
                         dbg_info("buffer could not be synced, ret_val: %d\n", ret_val);
                     }
@@ -552,6 +592,8 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
             if (ret_val != 0) {
                 pr_warn("user data could not be copied, return %d\n", ret_val);
             } else {
+                if (!ctid_valid(tmp[0]))
+                    return -EINVAL;
                 int32_t ctid = (int32_t) tmp[0];
                 dbg_info("marking notification with vfpga ID %d, ctid %d as processed\n", device->id, ctid);
                 mutex_unlock(&user_notifier_lock[device->id][ctid]);
@@ -568,6 +610,8 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
                 pr_warn("user data could not be copied, return %d\n", ret_val);
             } else {
                 // 2. send the interrupt value for this ctid!
+                if (!ctid_valid(tmp[0]))
+                    return -EINVAL;
                 int32_t ctid = (int32_t) tmp[0];
                 dbg_info("retrieving interrupt value for vfpga ID %d, ctid %d\n", device->id, ctid);
                 tmp[0] = interrupt_value[device->id][ctid];

--- a/driver/src/vfpga/vfpga_ops.c
+++ b/driver/src/vfpga/vfpga_ops.c
@@ -596,7 +596,7 @@ long vfpga_dev_ioctl(struct file *file, unsigned int command, unsigned long arg)
                     return -EINVAL;
                 int32_t ctid = (int32_t) tmp[0];
                 dbg_info("marking notification with vfpga ID %d, ctid %d as processed\n", device->id, ctid);
-                mutex_unlock(&user_notifier_lock[device->id][ctid]);
+                up(&user_notifier_lock[device->id][ctid]);
             }
             break;
         

--- a/driver/src/vfpga/vfpga_uisr.c
+++ b/driver/src/vfpga/vfpga_uisr.c
@@ -25,7 +25,7 @@
 struct eventfd_ctx *user_notifier[MAX_N_REGIONS][N_CTID_MAX];
 
 /// Every time a user interrupt is issued, the mutex is locked, avoiding race conditions until the interrupt has been handled
-struct mutex user_notifier_lock[MAX_N_REGIONS][N_CTID_MAX];
+struct semaphore user_notifier_lock[MAX_N_REGIONS][N_CTID_MAX];
 
 /// List of values that have been set for a interrupt for a vFPGA and Coyote thread.
 /// Values are set in vfpga_isr and read in vfpga_ops via ioctl.
@@ -35,7 +35,7 @@ int vfpga_register_eventfd(struct vfpga_dev *device, int ctid, int eventfd) {
     int ret_val = 0;
     BUG_ON(!device);
     
-    mutex_init(&user_notifier_lock[device->id][ctid]);
+    sema_init(&user_notifier_lock[device->id][ctid], 1);
 
     // Retrieve the kernel context from the eventfd file descriptor
     user_notifier[device->id][ctid] = eventfd_ctx_fdget(eventfd);


### PR DESCRIPTION
We run Coyote (`loom_host`) on a shared NixOS box (Linux 7.1, AMD EPYC) and saw random in-memory corruption of ZFS ARC buffers (lz4 decompress failures returning EIO, gone after `drop_caches`, pool clean) together with dozens of

```
WARNING: include/linux/rwsem.h:81 at find_vma+0x58/0x70, Comm: loom_host
 pin_user_pages_remote
 tlb_get_user_pages [coyote_driver]
 mmu_handler_gup [coyote_driver]
 vfpga_dev_ioctl [coyote_driver]
```

Auditing `vfpga_gup.c` turned up the following, fixed here as separate commits:

1. **Pages unpinned while the FPGA still maps them.** `tlb_unmap_gup()`/`migrate_to_*()` use `wait_event_interruptible()` and ignore the result. With a signal pending (always the case in `vfpga_dev_release()` when the process is killed) the wait returns immediately and the pages are `dma_unmap`ed + unpinned before the invalidation/DMA completes, so the device can write into memory the kernel has already reused. Switched to `wait_event()` / `wake_up()`.
2. **No `mmap_lock` / refcounts around GUP.** `find_vma()` and `pin_user_pages_remote()` were called without `mmap_read_lock()` (source of the WARN), the task/mm were used without `get_pid_task()`/`get_task_mm()`, and NULL task/VMA and negative GUP returns were not handled.
3. **Off-by-one in release lookup** (`<=` instead of `<`) tearing down the adjacent buffer, `hash_del()` inside non-`_safe` iteration, and `struct user_pages` never freed.
4. **OOB write** filling `hpages[]` for hugepages (bounds check after the store).

Build-tested on 6.6, 6.12, 6.18 and 7.2. Runtime-tested on U55C follows once our users are back on the machine; posting now since (1) and (3) can corrupt arbitrary host memory.

---

**Update:** pushed five more commits from a wider audit of the driver (same branch, each self-contained):

5. `validate ctid from user space and serialise teardown` — every ioctl used the user-supplied `ctid` unchecked as index into `pid_array[]`, `user_buff_map[][]`, `user_notifier[][]`, `interrupt_value[][]` (OOB kernel R/W from any user of the device node). Also: `mmu_lock` missing in offload/sync/unregister/release, non-`_safe` `hash_del` + leaks in release/unregister, NULL `pid_alloc` deref after `N_CTID_MAX` registrations, `pid_lock` leaked on HMM error.
6. `use a semaphore for the user notification handshake` — `struct mutex` locked in the workqueue and unlocked from the ioctl (different task), `mutex_init()` on a possibly held mutex; bound HW-reported `ctid` in ISR work handlers.
7. `fix lock leaks in card and reconfig memory allocation` — `alloc_card_memory()` returned with `card_lock` held; `mem_lock` was a spinlock around `vmalloc`/`kzalloc(GFP_KERNEL)`/`dma_map_single`/`remap_pfn_range` and leaked on two error paths.
8. `don't leave the shell decoupled when reconfiguration fails` — `rcnfg_lock` leaked + design left decoupled on error, wrong index (`tmp[3]` vs `tmp[4]`) for `reconfig_dcpl_app_clr`, interruptible completion wait, unchecked bitstream `len` reading past `hpages[]`.
9. `tie reconfig buffer lifetime to the user mapping` — `IOCTL_FREE_HOST_RECONFIG_MEM` freed pages still mapped in user space (user-visible UAF of physical pages). Pages are now owned by the VMA and freed in `vm_ops->close`.

All build-tested on 6.6 / 6.12 / 6.18 / 7.2.
